### PR TITLE
Update root address redirect

### DIFF
--- a/HerPublicWebsite/Controllers/StaticPagesController.cs
+++ b/HerPublicWebsite/Controllers/StaticPagesController.cs
@@ -21,6 +21,10 @@ public class StaticPagesController : Controller
     [HttpGet("/")]
     public IActionResult Index()
     {
+        #if DEBUG
+        return Redirect("/questionnaire/boiler");
+        #endif
+        
         return Redirect("https://www.gov.uk/apply-home-upgrade-grant");
     }
 


### PR DESCRIPTION
# Description

This redirects the root address when running locally to the start of the questionnaire. Previously this redirected to the live site.

# Checklist

- [ ] I have made any necessary updates to the documentation
- [ ] I have checked there are no unnecessary IDE warnings in this PR
- [ ] I have checked there are no unintentional line ending changes
- [ ] I have added tests where applicable
- [ ] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [ ] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVK6dT96k=/)
- [ ] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [ ] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the HUG2 Portal repository](https://github.com/UKGovernmentBEIS/desnz-home-energy-retrofit-portal-beta)
- [ ] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

 <!-- Add any screenshots of your changes, if applicable --> 
