### PR TITLE
PC-1643: Add full stop after council link

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/Ineligible.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/Ineligible.cshtml
@@ -33,7 +33,7 @@
              </p>
              <p class="govuk-body">
                  Based on the postcode and address you provided, your Local Authority is <a class="govuk-link" href="@Model.LocalAuthorityWebsite">@Model.LocalAuthorityName</a>.
-                 If this does not look right, you can <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your local council here</a>
+                 If this does not look right, you can <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your local council here</a>.
              </p>
     </text>;
 
@@ -47,7 +47,7 @@
              </p>
              <p class="govuk-body">
                  Based on the postcode and address you provided, your Local Authority is <a class="govuk-link" href="@Model.LocalAuthorityWebsite">@Model.LocalAuthorityName</a>.
-                 If this does not look right, you can <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your local council here</a>
+                 If this does not look right, you can <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your local council here</a>.
              </p>
     </text>;
 


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1643) (work to do with [PC-1608](https://beisdigital.atlassian.net/browse/PC-1608))

# Description

adds a missing full stop after the council link

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)

# Screenshots

![image](https://github.com/user-attachments/assets/5dfd5b94-9ce0-4ad5-b41a-fd2fb234549c)
