### PR TITLE
PC-1590: Fix back behaviour on country page

### DIFF
--- a/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
@@ -71,7 +71,7 @@ public class QuestionnaireController : Controller
         var viewModel = new CountryViewModel
         {
             Country = questionnaire.Country,
-            BackLink = GetBackUrl(QuestionFlowStep.Country, questionnaire, entryPoint)
+            BackLink = "https://www.gov.uk/apply-home-upgrade-grant"
         };
 
         return View("Country", viewModel);


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1590)

# Description

Fix to ensure country page, which is now the first page of the user journey, goes back to the grant home page (although it currently uses the HUG2 home page which is due to change).

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the WHLG Portal repository](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

 <!-- Add any screenshots of your changes, if applicable --> 
