### PR TITLE
PC-1749: Ensure SLA monitoring is reset for WH:LG

### DIFF
--- a/WhlgPublicWebsite.Data/DataAccessProvider.cs
+++ b/WhlgPublicWebsite.Data/DataAccessProvider.cs
@@ -8,6 +8,13 @@ namespace WhlgPublicWebsite.Data;
 public class DataAccessProvider(WhlgDbContext context)
     : IDataAccessProvider
 {
+    private static readonly DateTime Hug2ShutdownDate = new(2025, 02, 03);
+    
+    private static Expression<Func<ReferralRequest, bool>> IsExcludedFromSlaComplianceReporting => rr =>
+        !(rr.WasSubmittedForFutureGrants
+          || LocalAuthorityData.LiveWmcaCustodianCodes.Contains(rr.CustodianCode)
+          || rr.RequestDate <= Hug2ShutdownDate);
+
     public async Task<ReferralRequest> PersistNewReferralRequestAsync(ReferralRequest referralRequest)
     {
         context.ReferralRequests.Add(referralRequest);
@@ -73,7 +80,7 @@ public class DataAccessProvider(WhlgDbContext context)
             .Include(rr => rr.FollowUp)
             .ToListAsync();
     }
-    
+
     public async Task<IList<ReferralRequest>> GetAllWhlgReferralRequestsForSlaComplianceReporting()
     {
         return await context.ReferralRequests
@@ -157,11 +164,4 @@ public class DataAccessProvider(WhlgDbContext context)
         referralRequest.IsEligible = isEligible;
         await context.SaveChangesAsync();
     }
-    
-    private static readonly DateTime Hug2ShutdownDate = new(2025, 02, 03);
-
-    private static Expression<Func<ReferralRequest, bool>> IsExcludedFromSlaComplianceReporting => rr =>
-        !(rr.WasSubmittedForFutureGrants
-          || LocalAuthorityData.LiveWmcaCustodianCodes.Contains(rr.CustodianCode)
-          || rr.RequestDate <= Hug2ShutdownDate);
 }


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1749)

# Description

adds a filter to SLA compliance emails to the existing `IsExcludedFromSlaComplianceReporting` to ignore those made before 3rd February 2025.

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
