### PR TITLE
PC-1795: Remove horizontal rule on LA search headers

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/SelectLocalAuthority.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/SelectLocalAuthority.cshtml
@@ -67,7 +67,7 @@
                 var orderedLaDetails = localAuthoritiesForInitial.Value.OrderBy(lad => lad.Name).ToList();
                 var linksInFirstColumn = Math.Max((orderedLaDetails.Count + 1) / 2, 8);
                 <div id="@localAuthoritiesForInitial.Key" class="her_local_authority_section">
-                    <h2 class="govuk-heading-s">@localAuthoritiesForInitial.Key<hr/></h2>
+                    <h2 class="govuk-heading-m">@localAuthoritiesForInitial.Key</h2>
                 
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-one-half">


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1795)

# Description

removes the hr element as we found it to be used inappropriately here. it should be for separating paragraphs of text

to make the letters still prominent we increased their size to medium

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable

# Screenshots
![image](https://github.com/user-attachments/assets/4f69c860-9810-4f81-841e-335f80112456)
