### PR TITLE
PC-1821: Fix typo in household members bullet

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/HouseholdIncome.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/HouseholdIncome.cshtml
@@ -40,7 +40,7 @@
 
                                 <ul class="govuk-list govuk-list--bullet">
                                     <li>
-                                        from every household member (over 18) combined, excluding those in full-time education and lodgers, combined
+                                        from every household member (over 18), excluding those in full-time education and lodgers, combined
                                     </li>
                                     <li>
                                         including all benefits except Attendance Allowance; Disability Living Allowance; Personal Independence Payment;


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1821)

# Description

quick typo fix, 'combined' was written twice

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it

# Screenshots

![image](https://github.com/user-attachments/assets/813a88ae-206f-4550-ab73-4cda12e06a11)
