### PR TITLE
PC-1835: Remove references to monthly cadence for pending updates

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/Pending.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/Pending.cshtml
@@ -30,7 +30,7 @@
             This means that you can create an application, but they won't process it until they've signed up for the service.
         </p>
         <p class="govuk-body">
-            You will receive monthly updates from the Department of Energy Security and Net Zero
+            You will receive updates from the Department of Energy Security and Net Zero
             about the progress of your Local Authority signing up to use the service.
         </p>
 

--- a/WhlgPublicWebsite/Views/ReferralRequestFollowUp/ResponsePage.cshtml
+++ b/WhlgPublicWebsite/Views/ReferralRequestFollowUp/ResponsePage.cshtml
@@ -15,7 +15,7 @@
         <div class="govuk-body">
             <p>Thank you for taking part in the WH:LG Eligibility Checker on @Model.RequestDate.ToShortDateString().</p>
             <p>We are writing to check whether you have been contacted by your Local Authority (or their official contractor) in the last 10 working days.</p>
-            <p>Please do not submit a response to this question if at the time of submitting a referral you were told that your Local Authority is receiving applications but is not ready to process them yet. You will receive monthly updates from the Department of Energy Security and Net Zero about the status of your referral.</p>
+            <p>Please do not submit a response to this question if at the time of submitting a referral you were told that your Local Authority is receiving applications but is not ready to process them yet. You will receive updates from the Department of Energy Security and Net Zero about the status of your referral.</p>
             <p>Please indicate in the boxes below whether you have been contacted:</p>
         </div>
         <form action="@Url.Action(nameof(ReferralRequestFollowUpController.RespondPage_Post), "ReferralRequestFollowUp")" method="post" novalidate>


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1835)

# Description

removes usage of monthly in reference to pending emails being sent out.

removes usage identified on the ticket, as well as a further usage on the pending referral follow up page.

will also need to be removed from the email templates, though DESNZ can handle this one

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)

# Screenshots

![image](https://github.com/user-attachments/assets/61ebca40-2103-4c5f-8652-c2c0fed4f4fb)
