### PR TITLE
PC-1860: Update GovukNotify usage

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/WhlgPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -8,21 +8,13 @@ using WhlgPublicWebsite.BusinessLogic.Models;
 
 namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
 {
-    public class GovUkNotifyApi : IEmailSender
+    public class GovUkNotifyApi(
+        INotificationClient client,
+        IOptions<GovUkNotifyConfiguration> config,
+        ILogger<GovUkNotifyApi> logger)
+        : IEmailSender
     {
-        private readonly INotificationClient client;
-        private readonly GovUkNotifyConfiguration govUkNotifyConfig;
-        private readonly ILogger<GovUkNotifyApi> logger;
-        
-        public GovUkNotifyApi(
-            INotificationClient client,
-            IOptions<GovUkNotifyConfiguration> config,
-            ILogger<GovUkNotifyApi> logger)
-        {
-            this.client = client;
-            govUkNotifyConfig = config.Value;
-            this.logger = logger;
-        }
+        private readonly GovUkNotifyConfiguration govUkNotifyConfig = config.Value;
 
         private void SendEmail(GovUkNotifyEmailModel emailModel)
         {
@@ -53,44 +45,49 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                 }
             }
         }
-        
+
         public void SendReferenceCodeEmailForLiveLocalAuthority
         (
             string emailAddress,
-            string recipientName, 
+            string recipientName,
             ReferralRequest referralRequest)
         {
-            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest, govUkNotifyConfig.ReferenceCodeForLiveLocalAuthorityTemplate);
+            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
+                govUkNotifyConfig.ReferenceCodeForLiveLocalAuthorityTemplate);
         }
-        
+
         public void SendReferenceCodeEmailForTakingFutureReferralsLocalAuthority
         (
             string emailAddress,
             string recipientName,
             ReferralRequest referralRequest)
         {
-            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest, govUkNotifyConfig.ReferenceCodeForTakingFutureReferralsLocalAuthorityTemplate);
+            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
+                govUkNotifyConfig.ReferenceCodeForTakingFutureReferralsLocalAuthorityTemplate);
         }
-        
+
         public void SendReferenceCodeEmailForPendingLocalAuthority
         (
             string emailAddress,
             string recipientName,
             ReferralRequest referralRequest)
         {
-            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest, govUkNotifyConfig.ReferenceCodeForPendingLocalAuthorityTemplate);
+            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
+                govUkNotifyConfig.ReferenceCodeForPendingLocalAuthorityTemplate);
         }
 
         public void SendFollowUpEmail
         (
             ReferralRequest referralRequest,
             string followUpLink
-        ) {
+        )
+        {
             var template = govUkNotifyConfig.ReferralFollowUpTemplate;
             LocalAuthorityData.LocalAuthorityDetails localAuthorityDetails;
             try
             {
-                localAuthorityDetails = LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
+                localAuthorityDetails =
+                    LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
 
                 var personalisation = new Dictionary<string, dynamic>
                 {
@@ -118,8 +115,7 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                 );
             }
         }
-        
-        
+
         public void SendComplianceEmail(
             MemoryStream recentReferralRequestOverviewFileData,
             MemoryStream recentLocalAuthorityReferralRequestFollowUpFileData,
@@ -132,10 +128,25 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             var personalisation = new Dictionary<string, dynamic>
             {
                 { "OverviewFileLink", PrepareCsvUpload(recentReferralRequestOverviewFileData, "overview.csv") },
-                { "RecentLocalAuthorityFollowUpFileLink", PrepareCsvUpload(recentLocalAuthorityReferralRequestFollowUpFileData, "recent-local-authority-follow-up.csv") },
-                { "RecentConsortiumFollowUpFileLink", PrepareCsvUpload(recentConsortiumReferralRequestFollowUpFileData, "recent-consortium-follow-up.csv") },
-                { "HistoricLocalAuthorityFollowUpFileLink", PrepareCsvUpload(historicLocalAuthorityReferralRequestFollowUpFileData, "historic-local-authority-follow-up.csv") },
-                { "HistoricConsortiumFollowUpFileLink", PrepareCsvUpload(historicConsortiumReferralRequestFollowUpFileData, "historic-consortium-follow-up.csv") }, 
+                {
+                    "RecentLocalAuthorityFollowUpFileLink",
+                    PrepareCsvUpload(recentLocalAuthorityReferralRequestFollowUpFileData,
+                        "recent-local-authority-follow-up.csv")
+                },
+                {
+                    "RecentConsortiumFollowUpFileLink",
+                    PrepareCsvUpload(recentConsortiumReferralRequestFollowUpFileData, "recent-consortium-follow-up.csv")
+                },
+                {
+                    "HistoricLocalAuthorityFollowUpFileLink",
+                    PrepareCsvUpload(historicLocalAuthorityReferralRequestFollowUpFileData,
+                        "historic-local-authority-follow-up.csv")
+                },
+                {
+                    "HistoricConsortiumFollowUpFileLink",
+                    PrepareCsvUpload(historicConsortiumReferralRequestFollowUpFileData,
+                        "historic-consortium-follow-up.csv")
+                },
             };
             SendEmailToRecipients(recipientList, template.Id, personalisation);
         }
@@ -146,7 +157,10 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             var template = govUkNotifyConfig.PendingReferralReportTemplate;
             var personalisation = new Dictionary<string, dynamic>
             {
-                { template.LinkPlaceholder, PrepareCsvUpload(pendingReferralRequestsFileData, "pending-referral-requests.csv") },
+                {
+                    template.LinkPlaceholder,
+                    PrepareCsvUpload(pendingReferralRequestsFileData, "pending-referral-requests.csv")
+                },
             };
             SendEmailToRecipients(recipientList, template.Id, personalisation);
         }
@@ -161,7 +175,8 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             LocalAuthorityData.LocalAuthorityDetails localAuthorityDetails;
             try
             {
-                localAuthorityDetails = LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
+                localAuthorityDetails =
+                    LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
             }
             catch (KeyNotFoundException ex)
             {
@@ -177,6 +192,7 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                     ex
                 );
             }
+
             var personalisation = new Dictionary<string, dynamic>
             {
                 { template.RecipientNamePlaceholder, recipientName },
@@ -200,7 +216,7 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
         }
 
         private void SendEmailToRecipients(
-            string recipientList, 
+            string recipientList,
             string templateId,
             Dictionary<string, dynamic> personalisation)
         {
@@ -208,6 +224,7 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             {
                 return;
             }
+
             var emailAddresses = recipientList.Split(",").Select(emailAddress => emailAddress.Trim());
             foreach (var emailAddress in emailAddresses)
             {
@@ -221,12 +238,12 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
             }
         }
     }
-    
+
     internal class GovUkNotifyEmailModel
     {
-        public string EmailAddress { get; set; }
-        public string TemplateId { get; set; }
-        public Dictionary<string, dynamic> Personalisation { get; set; }
+        public string EmailAddress { get; init; }
+        public string TemplateId { get; init; }
+        public Dictionary<string, dynamic> Personalisation { get; init; }
         public string Reference { get; set; }
         public string EmailReplyToId { get; set; }
         public string OneClickUnsubscribeUrl { get; set; }

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApiTests.cs
@@ -30,7 +30,7 @@ public class GovUkNotifyApiTests
     {
         logger = new NullLogger<GovUkNotifyApi>();
         mockNotificationClient = new Mock<INotificationClient>();
-        
+
         config = new GovUkNotifyConfiguration
         {
             PendingReferralReportTemplate = new PendingReferralReportConfiguration
@@ -58,10 +58,10 @@ public class GovUkNotifyApiTests
         // Arrange
         const string recipient = "email1@example.com";
         config.PendingReferralEmailRecipients = recipient;
-        
+
         // Act
         govUkNotifyApi.SendPendingReferralReportEmail(memoryStream);
-        
+
         // Assert
         mockNotificationClient.Verify(nc => nc.SendEmail(
             recipient,
@@ -76,10 +76,10 @@ public class GovUkNotifyApiTests
         // Arrange
         const string recipient = "email1@example.com";
         config.PendingReferralEmailRecipients = recipient;
-        
+
         // Act
         govUkNotifyApi.SendPendingReferralReportEmail(memoryStream);
-        
+
         // Assert
         var personalisation = (Dictionary<string, object>)mockNotificationClient.Invocations[0].Arguments[2];
         personalisation.Should().ContainKey("link");
@@ -91,18 +91,18 @@ public class GovUkNotifyApiTests
         // Arrange
         var recipients = new[] { "email1@example.com", "email2@example.com", "email3@example.com" };
         config.PendingReferralEmailRecipients = string.Join(",", recipients);
-        
+
         // Act
         govUkNotifyApi.SendPendingReferralReportEmail(memoryStream);
-        
+
         // Assert
         mockNotificationClient.Verify(nc => nc.SendEmail(
-            It.IsAny<string>(),
-            config.PendingReferralReportTemplate.Id,
-            It.IsAny<Dictionary<string, object>>(),
-            null, null, null),
+                It.IsAny<string>(),
+                config.PendingReferralReportTemplate.Id,
+                It.IsAny<Dictionary<string, object>>(),
+                null, null, null),
             Times.Exactly(recipients.Length));
-        
+
         foreach (var recipient in recipients)
         {
             mockNotificationClient.Verify(nc => nc.SendEmail(
@@ -119,10 +119,10 @@ public class GovUkNotifyApiTests
         // Arrange
         const string recipient = "";
         config.PendingReferralEmailRecipients = recipient;
-        
+
         // Act
         govUkNotifyApi.SendPendingReferralReportEmail(memoryStream);
-        
+
         // Assert
         mockNotificationClient.Verify(nc => nc.SendEmail(
             It.IsAny<string>(),
@@ -136,10 +136,10 @@ public class GovUkNotifyApiTests
     {
         // Arrange
         config.PendingReferralEmailRecipients = null;
-        
+
         // Act
         govUkNotifyApi.SendPendingReferralReportEmail(memoryStream);
-        
+
         // Assert
         mockNotificationClient.Verify(nc => nc.SendEmail(
             It.IsAny<string>(),
@@ -147,23 +147,26 @@ public class GovUkNotifyApiTests
             It.IsAny<Dictionary<string, dynamic>>(),
             null, null, null), Times.Never);
     }
-    
+
     [TestCase(1, 10, 2022, "01/10/2022")]
     [TestCase(11, 1, 2023, "11/01/2023")]
     [TestCase(11, 12, 2023, "11/12/2023")]
-    public void SendFollowUpEmail_WhenCalled_SendsEmailWithUkDateFormat(int day, int month, int year, string expectedDateString)
+    public void SendFollowUpEmail_WhenCalled_SendsEmailWithUkDateFormat(int day, int month, int year,
+        string expectedDateString)
     {
         // Arrange
         var referralRequestBuilder = new ReferralRequestBuilder(1)
             .WithRequestDate(new DateTime(year, month, day))
-            .WithCustodianCode(LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus.Live));
+            .WithCustodianCode(
+                LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus
+                    .Live));
         var testReferralRequest = referralRequestBuilder.Build();
         var expectedKeyValuePair =
             new KeyValuePair<string, object>("TestReferralDate", expectedDateString);
-        
+
         // Act
         govUkNotifyApi.SendFollowUpEmail(testReferralRequest, "example");
-        
+
         // Assert
         mockNotificationClient.Verify(nc => nc.SendEmail(
             It.IsAny<string>(),


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1860)

# Description

oddly enough the pipeline for https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant/pull/104 didn't run so I didn't notice the build fail

these issues are now corrected

the library now recommends setting file names for downloaded files. they used to be random UUID file names

I added support for the new oneClickUnsubscribeUrl prop, though we don't currently use it. looking into the [docs](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant/pull/104) I don't think we need to provide these as of now - we don't currently send subscription emails with the app (either one off emails to users or to specified mailing lists)

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
