### PR TITLE
PC-1860: Update Community.Microsoft.Extensions.Caching.PostgreSql to 4.0.6

### DIFF
--- a/WhlgPublicWebsite/WhlgPublicWebsite.csproj
+++ b/WhlgPublicWebsite/WhlgPublicWebsite.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="CabinetOffice.GovUkDesignSystem" Version="1.0.0-1d1e0af" />
-        <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="3.1.2" />
+        <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="4.0.6" />
         <PackageReference Include="libphonenumber-csharp" Version="8.13.11" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.15" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.15" />


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1860)

# Description

npgsql swapped to using stored procedures https://www.npgsql.org/efcore/release-notes/7.0.html#other-new-features

the caching extension must be updated to support this https://github.com/leonibr/community-extensions-cache-postgres?tab=readme-ov-file#change-log else the session won't save correctly

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
