### PR TITLE
PC-1860: Downgrade Community.Microsoft.Extensions.Caching.PostgreSql to 4.0.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,13 @@ updates:
       # ensure FluentAssertions doesn't update to 8.x as its new license prohibit commercial use
       - dependency-name: "FluentAssertions"
         versions: ["8.x.x"]
+
       # Dependencies that cannot update to 9.x until we update to .NET 9
       - dependency-name: "Microsoft.EntityFrameworkCore.Design"
         versions: ["9.x.x"]
+      - dependency-name: "Community.Microsoft.Extensions.Caching.PostgreSql"
+        # 5.0.0 targets .NET 9
+        versions: ["5.x.x"]
 
   - package-ecosystem: "npm"
     directory: "WhlgPublicWebsite"

--- a/WhlgPublicWebsite/WhlgPublicWebsite.csproj
+++ b/WhlgPublicWebsite/WhlgPublicWebsite.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="CabinetOffice.GovUkDesignSystem" Version="1.0.0-1d1e0af" />
-        <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="5.0.0" />
+        <PackageReference Include="Community.Microsoft.Extensions.Caching.PostgreSql" Version="4.0.6" />
         <PackageReference Include="libphonenumber-csharp" Version="8.13.11" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.15" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.15" />


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1860)

# Description

the specific error I get while running mentions Npgsql, so it looks like this is an integration issue between these two dependencies

```
Unhandled exception. System.TypeLoadException: Could not load type 'Npgsql.Internal.HackyEnumTypeMapping' from assembly 'Npgsql, Version=9.0.2.0, Culture=neutral, PublicKeyToken=5d8b90d52f46fda7'.
   at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlTypeMappingSource.SetupEnumMappings(ISqlGenerationHelper sqlGenerationHelper, NpgsqlDataSource dataSource)
   at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlTypeMappingSource.LoadUserDefinedTypeMappings(ISqlGenerationHelper sqlGenerationHelper, NpgsqlDataSource dataSource)
   at Npgsql.EntityFrameworkCore.PostgreSQL.Storage.Internal.NpgsqlTypeMappingSource..ctor(TypeMappingSourceDependencies dependencies, RelationalTypeMappingSourceDependencies relationalDependencies, ISqlGenerationHelper sqlGenerationHelper, INpgsqlSingletonOptions options)
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   ...
```

https://github.com/leonibr/community-extensions-cache-postgres?tab=readme-ov-file#change-log suggests v5 targets .NET 9. we use .NET 8, so downgrading should be a straightforward fix

document this in the ignore file
