### PR TITLE
PC-1860: Change dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     # we may not be able to respond to pull requests immediately
     # prioritise showing them all
     open-pull-requests-limit: 100
@@ -28,7 +28,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "WhlgPublicWebsite"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 100
     # group all npm updates
     groups:


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1860)

# Description

as agreed on ticket, changes dependabot frequency to weekly from daily

this means we shouldn't get so many pull requests

identical to https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal/pull/67
