### PR TITLE
PC-1661: Tell ineligible users contact details have not been submitted

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/Ineligible.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/Ineligible.cshtml
@@ -106,7 +106,7 @@
                 {
                     Type = "success",
                     TitleText = "Success",
-                    Text = "Your contact details have been submitted.",
+                    Text = Model.CanContactByEmailAboutFutureSchemes is YesOrNo.Yes ? "Your contact details have been submitted." : "Your contact details have not been submitted.",
                     Role = "alert"
                 }
             )


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1661)

# Description

adds a check to decide whether to show the text "Your contact details have not been submitted" rather than always "Your contact details have been submitted"

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)

# Screenshots

![image](https://github.com/user-attachments/assets/03c36a7b-c8fe-4ff4-a838-935078a5edb7)
