### PR TITLE
PC-1885: Fix invalid text on household income field

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/Services/CsvFileCreator/CsvFileCreator.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Services/CsvFileCreator/CsvFileCreator.cs
@@ -10,33 +10,39 @@ namespace WhlgPublicWebsite.BusinessLogic.Services.CsvFileCreator;
 
 public interface ICsvFileCreator
 {
-    public MemoryStream CreateReferralRequestFileData(IEnumerable<ReferralRequest> referralRequests);
-    public MemoryStream CreateReferralRequestOverviewFileData(IEnumerable<ReferralRequest> referralRequests);
+    public MemoryStream CreateReferralRequestFileDataForS3(IEnumerable<ReferralRequest> referralRequests);
+    public MemoryStream CreateReferralRequestOverviewFileDataForS3(IEnumerable<ReferralRequest> referralRequests);
 
-    public MemoryStream CreateLocalAuthorityReferralRequestFollowUpFileData(
+    public MemoryStream CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(
         IEnumerable<ReferralRequest> referralRequests);
 
-    public MemoryStream CreateConsortiumReferralRequestFollowUpFileData(IEnumerable<ReferralRequest> referralRequests);
-    public MemoryStream CreatePendingReferralRequestFileData(IEnumerable<ReferralRequest> referralRequests);
-    public MemoryStream CreatePerMonthLocalAuthorityReferralStatistics(IEnumerable<ReferralRequest> referralRequests);
-    public MemoryStream CreatePerMonthConsortiumReferralStatistics(IEnumerable<ReferralRequest> referralRequests);
+    public MemoryStream CreateConsortiumReferralRequestFollowUpFileDataForS3(
+        IEnumerable<ReferralRequest> referralRequests);
+
+    public MemoryStream CreatePendingReferralRequestFileDataForS3(IEnumerable<ReferralRequest> referralRequests);
+
+    public MemoryStream CreatePerMonthLocalAuthorityReferralStatisticsForConsole(
+        IEnumerable<ReferralRequest> referralRequests);
+
+    public MemoryStream CreatePerMonthConsortiumReferralStatisticsForConsole(
+        IEnumerable<ReferralRequest> referralRequests);
 }
 
 public class CsvFileCreator : ICsvFileCreator
 {
-    public MemoryStream CreateReferralRequestFileData(IEnumerable<ReferralRequest> referralRequests)
+    public MemoryStream CreateReferralRequestFileDataForS3(IEnumerable<ReferralRequest> referralRequests)
     {
         var rows = referralRequests.Select(rr => new CsvRowReferralRequest(rr));
         return GenerateCsvMemoryStreamFromFileRows(rows, true);
     }
 
-    public MemoryStream CreateReferralRequestOverviewFileData(IEnumerable<ReferralRequest> referralRequests)
+    public MemoryStream CreateReferralRequestOverviewFileDataForS3(IEnumerable<ReferralRequest> referralRequests)
     {
         var rows = referralRequests.Select(rr => new CsvRowReferralCodes(rr));
         return GenerateCsvMemoryStreamFromFileRows(rows, true);
     }
 
-    public MemoryStream CreateLocalAuthorityReferralRequestFollowUpFileData(
+    public MemoryStream CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(
         IEnumerable<ReferralRequest> referralRequests)
     {
         var rows = referralRequests
@@ -45,7 +51,8 @@ public class CsvFileCreator : ICsvFileCreator
         return GenerateCsvMemoryStreamFromFileRows(rows, true);
     }
 
-    public MemoryStream CreateConsortiumReferralRequestFollowUpFileData(IEnumerable<ReferralRequest> referralRequests)
+    public MemoryStream CreateConsortiumReferralRequestFollowUpFileDataForS3(
+        IEnumerable<ReferralRequest> referralRequests)
     {
         var rows = referralRequests
             .GroupBy(rr => rr.CustodianCode)
@@ -62,7 +69,7 @@ public class CsvFileCreator : ICsvFileCreator
         return GenerateCsvMemoryStreamFromFileRows(rows, true);
     }
 
-    public MemoryStream CreatePendingReferralRequestFileData(IEnumerable<ReferralRequest> referralRequests)
+    public MemoryStream CreatePendingReferralRequestFileDataForS3(IEnumerable<ReferralRequest> referralRequests)
     {
         var rows = referralRequests
             .Select(rr => new CsvRowPendingReferralRequest(rr));
@@ -70,7 +77,7 @@ public class CsvFileCreator : ICsvFileCreator
         return GenerateCsvMemoryStreamFromFileRows(rows, true);
     }
 
-    public MemoryStream CreatePerMonthLocalAuthorityReferralStatistics(IEnumerable<ReferralRequest> requests)
+    public MemoryStream CreatePerMonthLocalAuthorityReferralStatisticsForConsole(IEnumerable<ReferralRequest> requests)
     {
         var rows = requests
             .GroupBy(r => r.CustodianCode)
@@ -79,7 +86,7 @@ public class CsvFileCreator : ICsvFileCreator
         return GenerateCsvMemoryStreamFromFileRows(rows, false);
     }
 
-    public MemoryStream CreatePerMonthConsortiumReferralStatistics(IEnumerable<ReferralRequest> requests)
+    public MemoryStream CreatePerMonthConsortiumReferralStatisticsForConsole(IEnumerable<ReferralRequest> requests)
     {
         var rows = requests
             .GroupBy(rr =>

--- a/WhlgPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralNotificationService.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Services/RegularJobs/PendingReferralNotificationService.cs
@@ -32,6 +32,6 @@ public class PendingReferralNotificationService
     {
         var referralRequests = await dataProvider.GetAllWhlgReferralRequests();
         var pendingReferralRequests = referralFilterService.FilterForPendingReferralReport(referralRequests);
-        return csvFileCreator.CreatePendingReferralRequestFileData(pendingReferralRequests);
+        return csvFileCreator.CreatePendingReferralRequestFileDataForS3(pendingReferralRequests);
     }
 }

--- a/WhlgPublicWebsite.BusinessLogic/Services/RegularJobs/PolicyTeamUpdateService.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Services/RegularJobs/PolicyTeamUpdateService.cs
@@ -56,7 +56,7 @@ public class PolicyTeamUpdateService : IPolicyTeamUpdate
         var startDate = await workingDayHelperService.AddWorkingDaysToDateTime(DateTime.Now.AddDays(-7), -10);
         var referrals = referralFilterService.FilterForSentToNonPending(
             await dataProvider.GetWhlgReferralRequestsBetweenDates(startDate, endDate));
-        return csvFileCreator.CreateReferralRequestOverviewFileData(referrals);
+        return csvFileCreator.CreateReferralRequestOverviewFileDataForS3(referrals);
     }
 
     private async Task<(DateTime, DateTime)> RecentReferralRequestTimePeriod()
@@ -71,15 +71,15 @@ public class PolicyTeamUpdateService : IPolicyTeamUpdate
         var (endDate, startDate) = await RecentReferralRequestTimePeriod();
         var referrals = referralFilterService.FilterForSentToNonPending(
             await dataProvider.GetWhlgReferralRequestsBetweenDates(startDate, endDate)).ToList();
-        return (csvFileCreator.CreateLocalAuthorityReferralRequestFollowUpFileData(referrals),
-            csvFileCreator.CreateConsortiumReferralRequestFollowUpFileData(referrals));
+        return (csvFileCreator.CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(referrals),
+            csvFileCreator.CreateConsortiumReferralRequestFollowUpFileDataForS3(referrals));
     }
 
     private async Task<(MemoryStream, MemoryStream)> BuildHistoricReferralRequestFollowUpFileData()
     {
         var referrals = referralFilterService.FilterForSentToNonPending(
             await dataProvider.GetAllWhlgReferralRequestsForSlaComplianceReporting()).ToList();
-        return (csvFileCreator.CreateLocalAuthorityReferralRequestFollowUpFileData(referrals),
-            csvFileCreator.CreateConsortiumReferralRequestFollowUpFileData(referrals));
+        return (csvFileCreator.CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(referrals),
+            csvFileCreator.CreateConsortiumReferralRequestFollowUpFileDataForS3(referrals));
     }
 }

--- a/WhlgPublicWebsite.BusinessLogic/Services/RegularJobs/UnsubmittedReferralRequestService.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Services/RegularJobs/UnsubmittedReferralRequestService.cs
@@ -36,7 +36,7 @@ public class UnsubmittedReferralRequestsService : IUnsubmittedReferralRequestsSe
                 await dataProvider.GetWhlgReferralRequestsByCustodianAndRequestDateAsync(grouping.CustodianCode,
                     grouping.Month, grouping.Year);
 
-            using (var fileData = csvFileCreator.CreateReferralRequestFileData(referralsForFile))
+            using (var fileData = csvFileCreator.CreateReferralRequestFileDataForS3(referralsForFile))
             {
                 await s3FileWriter.WriteFileAsync(grouping.CustodianCode, grouping.Month, grouping.Year, fileData);
             }

--- a/WhlgPublicWebsite.ManagementShell/CommandHandler.cs
+++ b/WhlgPublicWebsite.ManagementShell/CommandHandler.cs
@@ -84,17 +84,19 @@ public class CommandHandler(
         outputProvider.Output("Retrieving all WH:LG referrals submitted after HUG2 Shutdown.");
         var referralRequests = databaseOperation.GetAllWhlgReferralRequestsSubmittedAfterHug2Shutdown();
         outputProvider.Output("WH:LG Referrals retrieved successfully");
-        
+
         MemoryStream referralStatistics = null;
         switch (statisticsTypeSubcommand)
         {
             case AuthorityTypeSubcommand.LocalAuthority:
                 outputProvider.Output("Generating referrals per Local Authority per month CSV.");
-                referralStatistics = csvFileCreator.CreatePerMonthLocalAuthorityReferralStatistics(referralRequests);
+                referralStatistics =
+                    csvFileCreator.CreatePerMonthLocalAuthorityReferralStatisticsForConsole(referralRequests);
                 break;
             case AuthorityTypeSubcommand.Consortium:
                 outputProvider.Output("Generating referrals per Consortium per month CSV.");
-                referralStatistics = csvFileCreator.CreatePerMonthConsortiumReferralStatistics(referralRequests);
+                referralStatistics =
+                    csvFileCreator.CreatePerMonthConsortiumReferralStatisticsForConsole(referralRequests);
                 break;
         }
 

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CsvFileCreatorTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CsvFileCreatorTests.cs
@@ -17,7 +17,7 @@ namespace Tests.BusinessLogic.Services;
 public class CsvFileCreatorTests
 {
     [Test]
-    public void CreateReferralRequestFileData_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void CreateReferralRequestFileDataForS3_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -25,7 +25,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        var data = underTest.CreateReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -43,8 +43,9 @@ public class CsvFileCreatorTests
 #pragma warning restore CS0618
     [TestCase(IncomeBand.GreaterThan36000, "\"More than £36,000\"")]
     [TestCase(IncomeBand.UnderOrEqualTo36000, "\"£36,000 or less\"")]
-    public void CreateReferralRequestFileData_CalledWithReferralRequestWithIncomeAbove31k_GeneratesExpectedFileData(
-        IncomeBand incomeBand, string expectedValue)
+    public void
+        CreateReferralRequestFileDataForS3_CalledWithReferralRequestWithIncomeAbove31k_GeneratesExpectedFileData(
+            IncomeBand incomeBand, string expectedValue)
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -52,7 +53,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        var data = underTest.CreateReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -62,7 +63,7 @@ public class CsvFileCreatorTests
     }
 
     [Test]
-    public void CreateReferralRequestFileData_CalledWithReferralRequestWithUnsureEpc_GeneratesExpectedFileData()
+    public void CreateReferralRequestFileDataForS3_CalledWithReferralRequestWithUnsureEpc_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -70,7 +71,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        var data = underTest.CreateReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -80,7 +81,7 @@ public class CsvFileCreatorTests
     }
 
     [Test]
-    public void CreateReferralRequestFileData_CalledWithMultipleReferralRequests_GeneratesExpectedFileData()
+    public void CreateReferralRequestFileDataForS3_CalledWithMultipleReferralRequests_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -90,7 +91,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest1, referralRequest2, referralRequest3 };
 
         // Act
-        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        var data = underTest.CreateReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -105,7 +106,8 @@ public class CsvFileCreatorTests
     [TestCase("double\"quotes", "\"double\"\"quotes\"")]
     [TestCase("=Formula()", "Formula()")]
     [TestCase("+441234567890", "441234567890")]
-    public void CreateReferralRequestFileData_CalledWithSpecialCharacters_GeneratesEscapedFileData(string nameInput,
+    public void CreateReferralRequestFileDataForS3_CalledWithSpecialCharacters_GeneratesEscapedFileData(
+        string nameInput,
         string expectedOutput)
     {
         // Arrange
@@ -114,7 +116,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        var data = underTest.CreateReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -124,7 +126,7 @@ public class CsvFileCreatorTests
     }
 
     [Test]
-    public void CreateReferralRequestFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    public void CreateReferralRequestFileDataForS3_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -132,14 +134,14 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        var data = underTest.CreateReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
-    public void CreateReferralRequestOverviewFileData_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void CreateReferralRequestOverviewFileDataForS3_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -147,7 +149,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestOverviewFileData(referralRequests);
+        var data = underTest.CreateReferralRequestOverviewFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -158,7 +160,7 @@ public class CsvFileCreatorTests
 
     [Test]
     public void
-        CreateReferralRequestOverviewFileData_CalledWithReferralRequestFromNullConsortium_GeneratesExpectedFileData()
+        CreateReferralRequestOverviewFileDataForS3_CalledWithReferralRequestFromNullConsortium_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -167,7 +169,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestOverviewFileData(referralRequests);
+        var data = underTest.CreateReferralRequestOverviewFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -177,7 +179,7 @@ public class CsvFileCreatorTests
     }
 
     [Test]
-    public void CreateReferralRequestOverviewFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    public void CreateReferralRequestOverviewFileDataForS3_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -185,14 +187,15 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateReferralRequestOverviewFileData(referralRequests);
+        var data = underTest.CreateReferralRequestOverviewFileDataForS3(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
-    public void CreateLocalAuthorityReferralRequestFollowUpData_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void
+        CreateLocalAuthorityReferralRequestFollowUpFileDataForS3_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -221,7 +224,7 @@ public class CsvFileCreatorTests
         var today = DateTime.Today.ToString("dd-MMM");
 
         // Act
-        var data = underTest.CreateLocalAuthorityReferralRequestFollowUpFileData(referralRequests);
+        var data = underTest.CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -236,7 +239,7 @@ public class CsvFileCreatorTests
 
     [Test]
     public void
-        CreateLocalAuthorityReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+        CreateLocalAuthorityReferralRequestFollowUpFileDataForS3_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -244,14 +247,15 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateLocalAuthorityReferralRequestFollowUpFileData(referralRequests);
+        var data = underTest.CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
-    public void CreateConsortiumReferralRequestFollowUpData_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void
+        CreateConsortiumReferralRequestFollowUpFileDataForS3_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -282,7 +286,7 @@ public class CsvFileCreatorTests
 
         var today = DateTime.Today.ToString("dd-MMM");
         // Act
-        var data = underTest.CreateConsortiumReferralRequestFollowUpFileData(referralRequests);
+        var data = underTest.CreateConsortiumReferralRequestFollowUpFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -295,7 +299,8 @@ public class CsvFileCreatorTests
     }
 
     [Test]
-    public void CreateConsortiumReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    public void
+        CreateConsortiumReferralRequestFollowUpFileDataForS3_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -303,14 +308,14 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreateConsortiumReferralRequestFollowUpFileData(referralRequests);
+        var data = underTest.CreateConsortiumReferralRequestFollowUpFileDataForS3(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
-    public void CreatePendingReferralRequestFileData_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void CreatePendingReferralRequestFileDataForS3_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -342,7 +347,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest1, referralRequest2, referralRequest3 };
 
         // Act
-        var data = underTest.CreatePendingReferralRequestFileData(referralRequests);
+        var data = underTest.CreatePendingReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -354,7 +359,7 @@ public class CsvFileCreatorTests
     }
 
     [Test]
-    public void CreatePendingReferralRequestFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    public void CreatePendingReferralRequestFileDataForS3_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -362,14 +367,15 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreatePendingReferralRequestFileData(referralRequests);
+        var data = underTest.CreatePendingReferralRequestFileDataForS3(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
-    public void CreatePerMonthLocalAuthorityReferralStatistics_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void
+        CreatePerMonthLocalAuthorityReferralStatisticsForConsole_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -409,7 +415,7 @@ public class CsvFileCreatorTests
             { referralRequest1, referralRequest2, referralRequest3, referralRequest4, referralRequest5 };
 
         // Act
-        var data = underTest.CreatePerMonthLocalAuthorityReferralStatistics(referralRequests);
+        var data = underTest.CreatePerMonthLocalAuthorityReferralStatisticsForConsole(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -422,7 +428,7 @@ public class CsvFileCreatorTests
 
     [Test]
     public void
-        CreatePerMonthLocalAuthorityReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
+        CreatePerMonthLocalAuthorityReferralStatisticsForConsole_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -430,14 +436,15 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreatePerMonthLocalAuthorityReferralStatistics(referralRequests);
+        var data = underTest.CreatePerMonthLocalAuthorityReferralStatisticsForConsole(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeFalse();
     }
 
     [Test]
-    public void CreatePerMonthConsortiumReferralStatistics_CalledWithReferralRequest_GeneratesExpectedFileData()
+    public void
+        CreatePerMonthConsortiumReferralStatisticsForConsole_CalledWithReferralRequest_GeneratesExpectedFileData()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -470,7 +477,7 @@ public class CsvFileCreatorTests
             { referralRequest1, referralRequest2, referralRequest3, referralRequest4 };
 
         // Act
-        var data = underTest.CreatePerMonthConsortiumReferralStatistics(referralRequests);
+        var data = underTest.CreatePerMonthConsortiumReferralStatisticsForConsole(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -482,7 +489,7 @@ public class CsvFileCreatorTests
 
     [Test]
     public void
-        CreatePerMonthConsortiumReferralStatistics_CalledWithNonConsortiumReferralRequest_GeneratesFileDataWithoutNonConsortiumRequests()
+        CreatePerMonthConsortiumReferralStatisticsForConsole_CalledWithNonConsortiumReferralRequest_GeneratesFileDataWithoutNonConsortiumRequests()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -496,7 +503,7 @@ public class CsvFileCreatorTests
             { referralRequest1 };
 
         // Act
-        var data = underTest.CreatePerMonthConsortiumReferralStatistics(referralRequests);
+        var data = underTest.CreatePerMonthConsortiumReferralStatisticsForConsole(referralRequests);
 
         // Assert
         var reader = new StreamReader(data, Encoding.UTF8);
@@ -506,7 +513,7 @@ public class CsvFileCreatorTests
 
     [Test]
     public void
-        CreatePerMonthConsortiumReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
+        CreatePerMonthConsortiumReferralStatisticsForConsole_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -514,7 +521,7 @@ public class CsvFileCreatorTests
         var referralRequests = new List<ReferralRequest> { referralRequest };
 
         // Act
-        var data = underTest.CreatePerMonthConsortiumReferralStatistics(referralRequests);
+        var data = underTest.CreatePerMonthConsortiumReferralStatisticsForConsole(referralRequests);
 
         // Assert
         ContainsBom(data).Should().BeFalse();

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CsvFileCreatorTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CsvFileCreatorTests.cs
@@ -122,7 +122,7 @@ public class CsvFileCreatorTests
             "Referral date,Referral code,Name,Email,Telephone,Address1,Address2,Town,County,Postcode,UPRN,EPC Band,EPC confirmed by homeowner,EPC Lodgement Date,Household income band,Is eligible postcode,Tenure\r\n" +
             $"2023-01-01 13:00:01,DummyCode00001,{expectedOutput},contact1@example.com,00001 123456,Address 1 line 1,Address 1 line 2,Town1,County1,AL01 1RS,100 111 222 001,E,,2023-01-01 15:00:01,\"£36,000 or less\",no,Owner\r\n");
     }
-    
+
     [Test]
     public void CreateReferralRequestFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
@@ -133,7 +133,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreateReferralRequestFileData(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
@@ -175,7 +175,7 @@ public class CsvFileCreatorTests
             "Consortium,Local Authority,Referral Code\r\n" +
             ",Aberdeenshire Council,DummyCode00001\r\n");
     }
-    
+
     [Test]
     public void CreateReferralRequestOverviewFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
@@ -186,7 +186,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreateReferralRequestOverviewFileData(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
@@ -233,9 +233,10 @@ public class CsvFileCreatorTests
             $"{today},Aberdeenshire Council,1,33.333333333333336,2,66.66666666666667,3,100\r\n" // Custodian Code 9052
         );
     }
-    
+
     [Test]
-    public void CreateLocalAuthorityReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    public void
+        CreateLocalAuthorityReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -244,7 +245,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreateLocalAuthorityReferralRequestFollowUpFileData(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
@@ -292,7 +293,7 @@ public class CsvFileCreatorTests
             $"{today},Bristol City Council,False,3,60,False,2,40\r\n" // Custodian codes 114 and 121"
         ); // Stats for 9052 and 2205 with no Consortium name should not appear as LAs with no Consortium should not be included
     }
-    
+
     [Test]
     public void CreateConsortiumReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
@@ -303,7 +304,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreateConsortiumReferralRequestFollowUpFileData(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
@@ -351,7 +352,7 @@ public class CsvFileCreatorTests
             "Portsmouth City Council,Bedford Borough Council,2024-02-05 01:00:00,TEST0002,Test User 2,test2@example.com,,Live\r\n" +
             "Bristol City Council,North Somerset Council,2024-01-05 01:00:00,TEST0003,Test User 3,,333,Pending\r\n");
     }
-    
+
     [Test]
     public void CreatePendingReferralRequestFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
     {
@@ -362,7 +363,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreatePendingReferralRequestFileData(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeTrue();
     }
@@ -418,9 +419,10 @@ public class CsvFileCreatorTests
             $"Bedford Borough Council,Portsmouth City Council,1,{requestDate2:dd/MM/yyyy},3,0.33\r\n" +
             $"North Somerset Council,Bristol City Council,3,{requestDate3:dd/MM/yyyy},3,1\r\n");
     }
-    
+
     [Test]
-    public void CreatePerMonthLocalAuthorityReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
+    public void
+        CreatePerMonthLocalAuthorityReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -429,7 +431,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreatePerMonthLocalAuthorityReferralStatistics(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeFalse();
     }
@@ -477,9 +479,10 @@ public class CsvFileCreatorTests
             $"Bristol City Council,3,{requestDate2:dd/MM/yyyy},3,1\r\n" +
             $"Portsmouth City Council,1,{requestDate3:dd/MM/yyyy},3,0.33\r\n");
     }
-    
-        [Test]
-    public void CreatePerMonthConsortiumReferralStatistics_CalledWithNonConsortiumReferralRequest_GeneratesFileDataWithoutNonConsortiumRequests()
+
+    [Test]
+    public void
+        CreatePerMonthConsortiumReferralStatistics_CalledWithNonConsortiumReferralRequest_GeneratesFileDataWithoutNonConsortiumRequests()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -500,9 +503,10 @@ public class CsvFileCreatorTests
         reader.ReadToEnd().Should().Be(
             "Consortium Name,Total WH:LG Referrals,Date of First Referral,Months Since First Referral,Referrals Per Month\r\n");
     }
-    
+
     [Test]
-    public void CreatePerMonthConsortiumReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
+    public void
+        CreatePerMonthConsortiumReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
     {
         // Arrange
         var underTest = new CsvFileCreator();
@@ -511,7 +515,7 @@ public class CsvFileCreatorTests
 
         // Act
         var data = underTest.CreatePerMonthConsortiumReferralStatistics(referralRequests);
-        
+
         // Assert
         ContainsBom(data).Should().BeFalse();
     }

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CsvFileCreatorTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CsvFileCreatorTests.cs
@@ -122,6 +122,21 @@ public class CsvFileCreatorTests
             "Referral date,Referral code,Name,Email,Telephone,Address1,Address2,Town,County,Postcode,UPRN,EPC Band,EPC confirmed by homeowner,EPC Lodgement Date,Household income band,Is eligible postcode,Tenure\r\n" +
             $"2023-01-01 13:00:01,DummyCode00001,{expectedOutput},contact1@example.com,00001 123456,Address 1 line 1,Address 1 line 2,Town1,County1,AL01 1RS,100 111 222 001,E,,2023-01-01 15:00:01,\"£36,000 or less\",no,Owner\r\n");
     }
+    
+    [Test]
+    public void CreateReferralRequestFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreateReferralRequestFileData(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeTrue();
+    }
 
     [Test]
     public void CreateReferralRequestOverviewFileData_CalledWithReferralRequest_GeneratesExpectedFileData()
@@ -159,6 +174,21 @@ public class CsvFileCreatorTests
         reader.ReadToEnd().Should().Be(
             "Consortium,Local Authority,Referral Code\r\n" +
             ",Aberdeenshire Council,DummyCode00001\r\n");
+    }
+    
+    [Test]
+    public void CreateReferralRequestOverviewFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreateReferralRequestOverviewFileData(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
@@ -202,6 +232,21 @@ public class CsvFileCreatorTests
             $"{today},North Somerset Council,1,33.333333333333336,1,33.333333333333336,3,100\r\n" + // Custodian Code 121
             $"{today},Aberdeenshire Council,1,33.333333333333336,2,66.66666666666667,3,100\r\n" // Custodian Code 9052
         );
+    }
+    
+    [Test]
+    public void CreateLocalAuthorityReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreateLocalAuthorityReferralRequestFollowUpFileData(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
@@ -247,6 +292,21 @@ public class CsvFileCreatorTests
             $"{today},Bristol City Council,False,3,60,False,2,40\r\n" // Custodian codes 114 and 121"
         ); // Stats for 9052 and 2205 with no Consortium name should not appear as LAs with no Consortium should not be included
     }
+    
+    [Test]
+    public void CreateConsortiumReferralRequestFollowUpFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreateConsortiumReferralRequestFollowUpFileData(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeTrue();
+    }
 
     [Test]
     public void CreatePendingReferralRequestFileData_CalledWithReferralRequest_GeneratesExpectedFileData()
@@ -290,6 +350,21 @@ public class CsvFileCreatorTests
             "Bristol City Council,Bath and North East Somerset Council,2024-03-05 01:00:00,TEST0001,Test User 1,test1@example.com,111,Pending\r\n" +
             "Portsmouth City Council,Bedford Borough Council,2024-02-05 01:00:00,TEST0002,Test User 2,test2@example.com,,Live\r\n" +
             "Bristol City Council,North Somerset Council,2024-01-05 01:00:00,TEST0003,Test User 3,,333,Pending\r\n");
+    }
+    
+    [Test]
+    public void CreatePendingReferralRequestFileData_CalledWithReferralRequest_IncludesBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreatePendingReferralRequestFileData(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeTrue();
     }
 
     [Test]
@@ -342,6 +417,21 @@ public class CsvFileCreatorTests
             $"Bath and North East Somerset Council,Bristol City Council,1,{requestDate1:dd/MM/yyyy},1,1\r\n" +
             $"Bedford Borough Council,Portsmouth City Council,1,{requestDate2:dd/MM/yyyy},3,0.33\r\n" +
             $"North Somerset Council,Bristol City Council,3,{requestDate3:dd/MM/yyyy},3,1\r\n");
+    }
+    
+    [Test]
+    public void CreatePerMonthLocalAuthorityReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreatePerMonthLocalAuthorityReferralStatistics(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeFalse();
     }
 
     [Test]
@@ -409,5 +499,30 @@ public class CsvFileCreatorTests
         var reader = new StreamReader(data, Encoding.UTF8);
         reader.ReadToEnd().Should().Be(
             "Consortium Name,Total WH:LG Referrals,Date of First Referral,Months Since First Referral,Referrals Per Month\r\n");
+    }
+    
+    [Test]
+    public void CreatePerMonthConsortiumReferralStatistics_CalledWithReferralRequest_DoesNotIncludeBOMInTheMemoryStream()
+    {
+        // Arrange
+        var underTest = new CsvFileCreator();
+        var referralRequest = new ReferralRequestBuilder(1).Build();
+        var referralRequests = new List<ReferralRequest> { referralRequest };
+
+        // Act
+        var data = underTest.CreatePerMonthConsortiumReferralStatistics(referralRequests);
+        
+        // Assert
+        ContainsBom(data).Should().BeFalse();
+    }
+
+    private static bool ContainsBom(MemoryStream stream)
+    {
+        var utf8NoBom = new UTF8Encoding(false);
+        using var reader = new StreamReader(stream, utf8NoBom);
+        // if there is a BOM in the stream, the encoding will change to a BOM including encoding when its read 
+        reader.Read();
+        // this will make it no longer equal to this encoding where BOM is set to false
+        return !Equals(reader.CurrentEncoding, utf8NoBom);
     }
 }

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/PendingReferralNotificationServiceTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/PendingReferralNotificationServiceTests.cs
@@ -52,7 +52,7 @@ public class PendingReferralNotificationServiceTests
         var bytes = new byte[] { 0x0, 0x1, 0x2, 0x3 };
         var memoryStream = new MemoryStream(bytes);
         mockCsvFileCreator
-            .Setup(cfc => cfc.CreatePendingReferralRequestFileData(filteredReferralRequests))
+            .Setup(cfc => cfc.CreatePendingReferralRequestFileDataForS3(filteredReferralRequests))
             .Returns(memoryStream);
 
         // Act

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/PolicyTeamUpdateServiceTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/PolicyTeamUpdateServiceTests.cs
@@ -76,11 +76,11 @@ public class PolicyTeamUpdateServiceTests
         await policyTeamUpdateService.SendPolicyTeamUpdate();
 
         // Assert
-        mockCsvFileCreator.Verify(cfc => cfc.CreateReferralRequestOverviewFileData(
+        mockCsvFileCreator.Verify(cfc => cfc.CreateReferralRequestOverviewFileDataForS3(
             filteredReferrals), Times.Once);
-        mockCsvFileCreator.Verify(cfc => cfc.CreateLocalAuthorityReferralRequestFollowUpFileData(
+        mockCsvFileCreator.Verify(cfc => cfc.CreateLocalAuthorityReferralRequestFollowUpFileDataForS3(
             filteredReferrals), Times.Exactly(2));
-        mockCsvFileCreator.Verify(cfc => cfc.CreateConsortiumReferralRequestFollowUpFileData(
+        mockCsvFileCreator.Verify(cfc => cfc.CreateConsortiumReferralRequestFollowUpFileDataForS3(
             filteredReferrals), Times.Exactly(2));
         mockCsvFileCreator.VerifyNoOtherCalls();
     }


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1885)

# Description

adds an input to the CSV writing function to allow for the BOM to be output only when required.

required in contexts where we save the CSV as a file to ensure it is read correctly by downloaders

not wanted in contexts where we print the output to the console as it will be written as ?

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
