### PR TITLE
PC-1919: Ensure correct ineligible page is always shown

### DIFF
--- a/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
@@ -757,7 +757,6 @@ public class QuestionnaireController : Controller
         var viewModel = new IneligibleViewModel
         {
             EpcIsTooHigh = questionnaire.EpcIsTooHigh,
-            IncomeIsTooHigh = questionnaire.IncomeIsTooHigh,
             LocalAuthorityName = questionnaire.LocalAuthorityName,
             LocalAuthorityWebsite = questionnaire.LocalAuthorityWebsite,
             EmailAddress = questionnaire.NotificationEmailAddress,

--- a/WhlgPublicWebsite/Models/Questionnaire/IneligibleViewModel.cs
+++ b/WhlgPublicWebsite/Models/Questionnaire/IneligibleViewModel.cs
@@ -18,8 +18,6 @@ public class IneligibleViewModel : QuestionFlowViewModel
 
     public bool EpcIsTooHigh { get; set; }
 
-    public bool IncomeIsTooHigh { get; set; }
-
     public string LocalAuthorityName { get; set; }
 
     public string LocalAuthorityWebsite { get; set; }

--- a/WhlgPublicWebsite/Views/Questionnaire/Ineligible.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/Ineligible.cshtml
@@ -50,8 +50,6 @@
                  If this does not look right, you can <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your local council here</a>.
              </p>
     </text>;
-
-    var incomeHighButEpcLow = !Model.EpcIsTooHigh && Model.IncomeIsTooHigh;
 }
 
 @section BeforeMain {
@@ -65,38 +63,37 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         @{
-            switch (Model.EpcIsTooHigh, Model.IncomeIsTooHigh)
+            if (Model.EpcIsTooHigh)
             {
-                case (true, false):
-                    <h1 class="govuk-heading-l">We do not think you are eligible</h1>
-                    <p class="govuk-body">
-                        We do not think you are eligible for the Warm Homes: Local Grant because your
-                        EPC rating is A, B, or C but you may be able to get other help for your energy needs.
-                    </p>
-                    break;
-                default:
-                    <h1 class="govuk-heading-l">We cannot auto-refer you, but you may still be eligible</h1>
-                    <p class="govuk-body">
-                        Based on information you have provided we are unable to automatically refer you to your Local Authority
-                        at this time. If you think you might qualify through another eligibility route, please contact
-                        your Local Authority directly.
-                    </p>
-                    <p class="govuk-body">Other eligibility routes may include:</p>
-                    <ul class="govuk-list govuk-list--bullet">
-                        <li>Receiving a specified means-tested benefit</li>
-                        <li>Having a household income above £36,000 but falling below the after housing costs threshold due to high housing expenses</li>
-                    </ul>
-                    break;
+                <h1 class="govuk-heading-l">We do not think you are eligible</h1>
+                <p class="govuk-body">
+                    We do not think you are eligible for the Warm Homes: Local Grant because your
+                    EPC rating is A, B, or C but you may be able to get other help for your energy needs.
+                </p>
+            }
+            else
+            {
+                <h1 class="govuk-heading-l">We cannot auto-refer you, but you may still be eligible</h1>
+                <p class="govuk-body">
+                    Based on information you have provided we are unable to automatically refer you to your Local Authority
+                    at this time. If you think you might qualify through another eligibility route, please contact
+                    your Local Authority directly.
+                </p>
+                <p class="govuk-body">Other eligibility routes may include:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Receiving a specified means-tested benefit</li>
+                    <li>Having a household income above £36,000 but falling below the after housing costs threshold due to high housing expenses</li>
+                </ul>
             }
         }
 
-        @if (incomeHighButEpcLow)
+        @if (Model.EpcIsTooHigh)
         {
-            @yourLaMayBeAbleToHelpSection(new object())
+            @otherGovernmentSchemesSection(new object())
         }
         else
         {
-            @otherGovernmentSchemesSection(new object())
+            @yourLaMayBeAbleToHelpSection(new object())
         }
 
         @if (Model.Submitted)
@@ -157,13 +154,13 @@
             </form>
         }
 
-        @if (incomeHighButEpcLow)
+        @if (Model.EpcIsTooHigh)
         {
-            @otherGovernmentSchemesSection(new object())
+            @contactYourLaSection(new object())
         }
         else
         {
-            @contactYourLaSection(new object())
+            @otherGovernmentSchemesSection(new object())
         }
 
         <h2 class="govuk-heading-m">Find further support</h2>


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1919)

# Description

simplified the view a bit. there are now only two options and EPC being low now implies income is high, so only needed to check EPC

have checked against the miro & page contents on these two journeys have not changed

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent

# Screenshots
![image](https://github.com/user-attachments/assets/196cd2b9-9c89-42fb-a9fb-c8bf336b6482)
![image](https://github.com/user-attachments/assets/d90d6b38-b81a-49e9-abf8-a8be503bd859)
