### PR TITLE
PC-1894: Allow for manual running of exporting referrals to the portal

### DIFF
--- a/WhlgPublicWebsite.ManagementShell/CommandLineUnsubmittedReferralRequestsService.cs
+++ b/WhlgPublicWebsite.ManagementShell/CommandLineUnsubmittedReferralRequestsService.cs
@@ -1,0 +1,43 @@
+﻿using Amazon;
+using Amazon.S3;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using WhlgPublicWebsite.BusinessLogic.ExternalServices.S3FileWriter;
+using WhlgPublicWebsite.BusinessLogic.Services.CsvFileCreator;
+using WhlgPublicWebsite.BusinessLogic.Services.RegularJobs;
+using WhlgPublicWebsite.BusinessLogic.Services.S3ReferralFileKeyGenerator;
+using WhlgPublicWebsite.Data;
+
+namespace WhlgPublicWebsite.ManagementShell;
+
+/**
+ * Wraps the mechanism required to create an instance of the UnsubmittedReferralRequestsService.
+ * For use only with the CLI code, otherwise use DI to get an instance of IUnsubmittedReferralRequestsService.
+ */
+public class CommandLineUnsubmittedReferralRequestsService
+{
+    private UnsubmittedReferralRequestsService UnsubmittedReferralRequestsService { get; }
+
+    public CommandLineUnsubmittedReferralRequestsService(WhlgDbContext context)
+    {
+        var dataAccessProvider = new DataAccessProvider(context);
+        var s3Config = new S3Configuration
+        {
+            BucketName = Environment.GetEnvironmentVariable("S3__BucketName"),
+            Region = Environment.GetEnvironmentVariable("S3__Region")
+        };
+        var s3FileWriterLogger = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<S3FileWriter>();
+        var s3ReferralFileKeyGenerator = new S3ReferralFileKeyGenerator();
+        var s3Client = new AmazonS3Client(RegionEndpoint.GetBySystemName(s3Config.Region));
+        var s3FileWriter = new S3FileWriter(Options.Create(s3Config), s3FileWriterLogger, s3ReferralFileKeyGenerator,
+            s3Client);
+        var csvFileCreator = new CsvFileCreator();
+        UnsubmittedReferralRequestsService =
+            new UnsubmittedReferralRequestsService(dataAccessProvider, s3FileWriter, csvFileCreator);
+    }
+
+    public Task WriteUnsubmittedReferralRequestsToCsv()
+    {
+        return UnsubmittedReferralRequestsService.WriteUnsubmittedReferralRequestsToCsv();
+    }
+}

--- a/WhlgPublicWebsite.ManagementShell/Program.cs
+++ b/WhlgPublicWebsite.ManagementShell/Program.cs
@@ -45,6 +45,9 @@ public static class Program
             case Subcommand.GeneratePerMonthStatistics:
                 commandHandler.GeneratePerMonthStatistics(subcommandArgs);
                 return;
+            case Subcommand.ExportNewReferralRequestsToPortal:
+                _ = commandHandler.ExportNewReferralRequestsToPortal(context);
+                return;
             default:
                 outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");
                 return;
@@ -54,6 +57,7 @@ public static class Program
     private enum Subcommand
     {
         GenerateReferrals,
-        GeneratePerMonthStatistics
+        GeneratePerMonthStatistics,
+        ExportNewReferralRequestsToPortal
     }
 }


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1894)

# Description

adds a command to the CLI to allow for the `WriteUnsubmittedReferralRequestsToCsv` job to be run using the CLI

added a class `CommandLineUnsubmittedReferralRequestsService` to encapsulate the process of constructing this class to keep this away from the rest of the CLI

coded to not run on production (no need) nor local dev (no access)

also checks the necessary environment variables are set

# Checklist

- [x] I have made any necessary updates to the [documentation](https://softwiretech.atlassian.net/wiki/spaces/Support/pages/21542961153/DESNZ+WH+LG+CLI+Database+Tasks#6.-Export-referral-requests-to-the-Portal)
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
