### PR TITLE
PC-1894: Fix program not awaiting export result

### DIFF
--- a/WhlgPublicWebsite.ManagementShell/Program.cs
+++ b/WhlgPublicWebsite.ManagementShell/Program.cs
@@ -6,7 +6,7 @@ namespace WhlgPublicWebsite.ManagementShell;
 
 public static class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
         var outputProvider = new OutputProvider();
         var contextOptions = new DbContextOptionsBuilder<WhlgDbContext>()
@@ -46,7 +46,7 @@ public static class Program
                 commandHandler.GeneratePerMonthStatistics(subcommandArgs);
                 return;
             case Subcommand.ExportNewReferralRequestsToPortal:
-                _ = commandHandler.ExportNewReferralRequestsToPortal(context);
+                await commandHandler.ExportNewReferralRequestsToPortal(context);
                 return;
             default:
                 outputProvider.Output("Invalid terminal command entered. Please refer to the documentation");


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1894)

# Description

previously as we ignored the async task result the program would start the async task, then hit the return and exit without waiting for the task to finish

with no explicit blocker it would try to dispose the connection immediately causing issues. makes Main async here so we can use await & have the main thread stick around until the operation is finished

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
