### PR TITLE
PC-1930: Remove unneeded ItemGroup for rebrand assets

### DIFF
--- a/WhlgPublicWebsite/WhlgPublicWebsite.csproj
+++ b/WhlgPublicWebsite/WhlgPublicWebsite.csproj
@@ -35,9 +35,4 @@
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
     </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="wwwroot\assets\rebrand\" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1930)

# Description

could be breaking the new rebrand assets from being served on dev

<img width="479" height="164" alt="image" src="https://github.com/user-attachments/assets/e4a30f77-7afe-49be-9e07-a13030a24508" />

this should be included in the above Include="wwwroot\**\*"

was added automatically by rider

[portal](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal/blob/develop/WhlgPortalWebsite/WhlgPortalWebsite.csproj) does not have this section and works fine
