### PR TITLE
PC-2026: Remove wording referring to DESNZ notifying users

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/Pending.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/Pending.cshtml
@@ -29,10 +29,6 @@
             is not signed up to use this service yet.
             This means that you can create an application, but they won't process it until they've signed up for the service.
         </p>
-        <p class="govuk-body">
-            You will receive updates from the Department of Energy Security and Net Zero
-            about the progress of your Local Authority signing up to use the service.
-        </p>
 
         <p class="govuk-body">
             If your Local Authority does not seem to be right, <a class="govuk-link" href="https://www.gov.uk/find-local-council">find your correct Local Authority</a> and contact them directly.


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-2026)

# Description

- Removed wording referring to DESNZ notifying users about LA going 'live' from 'pending'

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)

# Screenshots
## New pending LA page
<img width="1462" height="1676" alt="{785602FB-4142-4F96-BFC2-26769A880303}" src="https://github.com/user-attachments/assets/ab4203a1-a92d-4309-b4b7-21cb84c51501" />
