### PR TITLE
PC-1859: Move the shared ownership hint to a separate details

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/OwnershipStatus.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/OwnershipStatus.cshtml
@@ -34,15 +34,18 @@
                         Classes = "govuk-fieldset__legend--l",
                         IsPageHeading = true
                     }
-                },
-                hintOptions: new HintViewModel
-                {
-                    Html = @<text>
-                                <p class="govuk-body">
-                                    If you have a <a class="govuk-link" href="https://www.gov.uk/shared-ownership-scheme">shared ownership property</a>, please select "@Model.SharedOwnershipAnswerLabel".
-                                </p>
-                            </text>
                 })
+            
+            @await Html.GovUkDetails(new DetailsViewModel
+            {
+                SummaryText = "I live in a shared ownership property",
+                Html = 
+                    @<text>
+                        <p class="govuk-body">
+                            If you have a <a class="govuk-link" href="https://www.gov.uk/shared-ownership-scheme">shared ownership property</a>, please select "@Model.SharedOwnershipAnswerLabel".
+                        </p>
+                    </text>
+            })
 
             @(await Html.GovUkButton(new ButtonViewModel
             {


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1859)

# Description

this is more GDS compliant as they recommend not putting links in hint texts as it can cause issues for screen readers

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)

# Screenshots

<img alt="new ownership status page" src="https://github.com/user-attachments/assets/e26ffc3d-1adc-4c9c-9ce7-2470d981b0be" />

