### PR TITLE
PC-1769: Trim whitespace on email addresses captured by questionnaire

### DIFF
--- a/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
@@ -416,7 +416,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("not-taking-part")]
-    public async Task<IActionResult> NoFunding_Post(IneligibleViewModel viewModel)
+    public async Task<IActionResult> NoFunding_Post(NoFundingViewModel viewModel)
     {
         if (!ModelState.IsValid) return await NoFunding_Get(viewModel.EntryPoint);
 
@@ -463,7 +463,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("not-participating")]
-    public async Task<IActionResult> NotParticipating_Post(IneligibleViewModel viewModel)
+    public async Task<IActionResult> NotParticipating_Post(NotParticipatingViewModel viewModel)
     {
         if (!ModelState.IsValid) return await NotParticipating_Get(viewModel.EntryPoint);
         
@@ -507,7 +507,7 @@ public class QuestionnaireController : Controller
     }
 
     [HttpPost("no-longer-participating")]
-    public async Task<IActionResult> NoLongerParticipating_Post(IneligibleViewModel viewModel)
+    public async Task<IActionResult> NoLongerParticipating_Post(NoLongerParticipatingViewModel viewModel)
     {
         if (!ModelState.IsValid) return NoLongerParticipating_Get(viewModel.EntryPoint);
         


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1769)

# Description

wraps all calls to email addresses in QuestionnaireController with .Trim()

also fixes a bug where we were using the wrong view models on a couple POST views. since we were using the same attributes of the POST across models this worked fine, but could lead to issues in the future

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
