### PR TITLE
PC-1580: Run the app using Docker when developing locally

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+COPY . .
+
+ENTRYPOINT ["dotnet", "test"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ Note, the WH:LG project is split across 2 repositories:
 
 ### Pre-requisites
 
+For quick setup (running with docker compose):
+- Docker Desktop (https://www.docker.com/products/docker-desktop/)
 - .Net 8 (https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+
+### Optional requirements
+Recommended if you want to run the project in Rider with access to local tools, such as the debugger and EF migrations:
 - Install EF Core CLI tools (https://docs.microsoft.com/en-us/ef/core/cli/dotnet)
 - Node v14+ (https://nodejs.org/en/)
 - If you're using Rider then you will need to install the ".net core user secrets" plugin
@@ -23,6 +28,8 @@ Note, the WH:LG project is split across 2 repositories:
 In WhlgPublicWebsite run `npm install`
 
 ### Minio
+
+If using docker minio will be configured automatically.
 
 The database of referrals is copied nightly from postgres to an S3 bucket. For local development we need a fake S3 bucket to connect to. To use [Minio](https://min.io/) to provide a local S3 bucket follow these steps:
 1. Download minio
@@ -84,6 +91,8 @@ cat secrets.json | dotnet user-secrets set
 
 ### Local database setup
 
+If using docker the database will be configured automatically.
+
 #### Windows
 - Download the installer and PostgreSQL 15 [here](https://www.postgresql.org/download/windows/)
 - Follow default installation steps (no additional software is required from Stack Builder upon completion)
@@ -105,6 +114,12 @@ For further information on interacting with the database and using migrations, p
 
 ### Running the service locally
 
+#### Docker
+
+If using docker, run `docker compose up --build`, then visit http://localhost:5000/questionnaire/
+
+#### Without Docker
+
 - Ensure Minio is running:
   * Windows
       * In your Minio folder un `.\minio.exe server <path to data folder> --console-address :9090`
@@ -114,9 +129,15 @@ For further information on interacting with the database and using migrations, p
 - In Rider build the solution
 - In `WhlgPublicWebsite` run `npm run watch`
 - In Rider run the `WhlgPublicWebsite` project
-- In a browser, visit https://localhost:5001/questionnaire/
+- In a browser, visit http://localhost:5000/questionnaire/
 
 ### Running tests
+
+#### Docker
+
+If using docker, run `docker compose -f docker-compose.test.yml run --rm --build tests`.
+
+#### Without Docker
 
 - In the project explorer on the left, right click on `WhlgPublicWebsite.UnitTests` and select `Run Unit Tests`
 - Note, if you've previously run `npm run watch` you'll have to terminate this (`ctrl`/`cmd` + `c`) before running the tests.
@@ -210,3 +231,5 @@ This is likely because the CSS hasn't been built. To fix this:
 - Navigate to the `WhlgPublicWebsite` directory
 - Run `npm install` to install any new dependencies
 - Run `npm run build` to build the CSS
+
+Note that running with docker compose will do this automatically.

--- a/WhlgPublicWebsite.ManagementShell/Program.cs
+++ b/WhlgPublicWebsite.ManagementShell/Program.cs
@@ -12,7 +12,7 @@ public static class Program
         var contextOptions = new DbContextOptionsBuilder<WhlgDbContext>()
             .UseNpgsql(
                 Environment.GetEnvironmentVariable("ConnectionStrings__PostgreSQLConnection") ??
-                @"UserId=postgres;Password=postgres;Server=localhost;Port=5432;Database=whlgdev;Include Error Detail=true;Pooling=true")
+                @"UserId=postgres;Password=postgres;Server=db;Port=5432;Database=whlgdev;Include Error Detail=true;Pooling=true")
             .Options;
         using var context = new WhlgDbContext(contextOptions);
         var csvFileCreator = new CsvFileCreator();

--- a/WhlgPublicWebsite/Properties/launchSettings.json
+++ b/WhlgPublicWebsite/Properties/launchSettings.json
@@ -23,7 +23,8 @@
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation",
+        "ConnectionStrings__PostgreSQLConnection": "UserId=postgres;Password=postgres;Server=localhost;Port=5432;Database=whlgdev;Include Error Detail=true;Pooling=true"
       }
     }
   }

--- a/WhlgPublicWebsite/Startup.cs
+++ b/WhlgPublicWebsite/Startup.cs
@@ -160,7 +160,7 @@ public class Startup
         {
             options.Cookie.Name = "Antiforgery";
             options.Cookie.HttpOnly = true;
-            options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+            options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
         });
         services.AddScoped<CookieService, CookieService>();
     }
@@ -266,10 +266,6 @@ public class Startup
         }
 
         app.UseStatusCodePagesWithReExecute("/error/{0}");
-
-        if (webHostEnvironment.IsDevelopment())
-            // In production we terminate TLS at the load balancer and redirect there
-            app.UseHttpsRedirection();
 
         app.Use(async (context, next) =>
         {

--- a/WhlgPublicWebsite/appsettings.Development.json
+++ b/WhlgPublicWebsite/appsettings.Development.json
@@ -2,6 +2,6 @@
     "S3": {
         "LocalDevOnly_AccessKey": "minioadmin",
         "LocalDevOnly_SecretKey": "minioadmin",
-        "LocalDevOnly_ServiceURL": "http://localhost:9000"
+        "LocalDevOnly_ServiceURL": "http://minio:9000"
     }
 }

--- a/WhlgPublicWebsite/appsettings.json
+++ b/WhlgPublicWebsite/appsettings.json
@@ -4,7 +4,7 @@
     },
 
     "ConnectionStrings": {
-        "PostgreSQLConnection": "UserId=postgres;Password=postgres;Server=localhost;Port=5432;Database=whlgdev;Include Error Detail=true;Pooling=true"
+        "PostgreSQLConnection": "UserId=postgres;Password=postgres;Server=db;Port=5432;Database=whlgdev;Include Error Detail=true;Pooling=true"
     },
 
     "Logging": {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,5 @@
+﻿services:
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,74 @@
+﻿services:
+  app:
+    build:
+      context: .
+      args:
+        # If running docker-compose via a run configuration in Rider, it will
+        # override this with whatever build configuration you have selected.
+        # This is clever and kind of it, but a bit surprising!
+        CONFIGURATION: "Debug"
+    ports:
+      - "5000:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: "Development"
+      ASPNETCORE_HTTP_PORTS: "8080"
+    volumes:
+      # map the dotnet user-secret folder
+      - $APPDATA/Microsoft/UserSecrets:/home/appuser/.microsoft/usersecrets:ro
+    depends_on:
+      db:
+        condition: service_healthy
+        restart: true
+      minio:
+        condition: service_healthy
+  db:
+    image: postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: whlgdev
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  minio:
+    image: minio/minio
+    container_name: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  minio-setup:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 minioadmin minioadmin;
+        mc mb -p local/desnz-whlg-portal-referrals;
+        exit 0;
+      "
+  tests:
+    build:
+      context: .
+    command: ["dotnet", "test"]
+    profiles: ["test"]
+    
+volumes:
+  minio-data:
+    name: whlg-minio-data


### PR DESCRIPTION
[Link to Jira ticket](https://beisdigital.atlassian.net/browse/PC-1580)

# Description

adds docker compose files to run the app locally.

the docker compose pulls the necessary dependencies (postgres, minio) and will configure them. minio is set up in such a way that referrals should share to the portal when run locally too

also adds a quick test runner docker compose, though this can maybe be dropped (.NET 8 is still recommended to be installed locally & there's no external dependencies)

updates readme to account for this (based off the PC-2003 branch's README changes)

disables https redirects when working locally. https doesn't work well with the docker container & I don't think there's a requirement to use it locally.

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
