### PR TITLE
DESNZ-1533: Remove summary component list title from EPC summary page

### DIFF
--- a/WhlgPublicWebsite/Views/Questionnaire/ReviewEpc.cshtml
+++ b/WhlgPublicWebsite/Views/Questionnaire/ReviewEpc.cshtml
@@ -27,51 +27,44 @@
             This certificate may be registered to your property or one of the properties nearby that shares part of your address.
         </p>
 
-        <div class="govuk-summary-card">
-            <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title govuk-heading-m">Certificate</h2>
-            </div>
-            <div class="govuk-summary-card__content">
-                @await Html.GovUkSummaryList(new SummaryListViewModel
-                       {
-                           Rows = new List<SummaryListRowViewModel>
-                           {
-                               new()
-                               {
-                                   Key = new SummaryListRowKey { Text = "Registered address" },
-                                   Value = new SummaryListRowValue
-                                   {
-                                       Html = @<text>@Html.Raw(Model.AddressRawHtml)</text>
-                                   }
-                               },
-                               new()
-                               {
-                                   Key = new SummaryListRowKey { Text = "Energy rating" },
-                                   Value = new SummaryListRowValue
-                                   {
-                                       Text = Model.EpcBand
-                                   }
-                               },
-                               new()
-                               {
-                                   Key = new SummaryListRowKey { Text = "Valid from" },
-                                   Value = new SummaryListRowValue
-                                   {
-                                       Text = Model.ValidFrom
-                                   }
-                               },
-                               new()
-                               {
-                                   Key = new SummaryListRowKey { Text = "Valid until" },
-                                   Value = new SummaryListRowValue
-                                   {
-                                       Text = Model.ValidUntil
-                                   }
-                               }
-                           }
-                       })
-            </div>
-        </div>
+        @await Html.GovUkSummaryList(new SummaryListViewModel
+        {
+            Rows = new List<SummaryListRowViewModel>
+            {
+                new()
+                {
+                    Key = new SummaryListRowKey { Text = "Registered address" },
+                    Value = new SummaryListRowValue
+                    {
+                        Html = @<text>@Html.Raw(Model.AddressRawHtml)</text>
+                    }
+                },
+                new()
+                {
+                    Key = new SummaryListRowKey { Text = "Energy rating" },
+                    Value = new SummaryListRowValue
+                    {
+                        Text = Model.EpcBand
+                    }
+                },
+                new()
+                {
+                    Key = new SummaryListRowKey { Text = "Valid from" },
+                    Value = new SummaryListRowValue
+                    {
+                        Text = Model.ValidFrom
+                    }
+                },
+                new()
+                {
+                    Key = new SummaryListRowKey { Text = "Valid until" },
+                    Value = new SummaryListRowValue
+                    {
+                        Text = Model.ValidUntil
+                    }
+                }
+            }
+        })
         
         <form action="@Url.Action(nameof(QuestionnaireController.ReviewEpc_Post), "Questionnaire")" method="post" novalidate>
             @(Html.HiddenFor(m => m.EntryPoint))


### PR DESCRIPTION
[Link to Jira ticket](https://softwiretech.atlassian.net/browse/DESNZ-1533)

# Description

Removed the summary component list title from the EPC summary page.

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the WHLG Portal repository](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

Before:
<img width="652" height="540" alt="image" src="https://github.com/user-attachments/assets/98ff69b9-8fda-4a18-aad8-5fb2c7852530" />

After:
<img width="660" height="443" alt="image" src="https://github.com/user-attachments/assets/4f1e5a50-ac15-4322-99fe-25a314236675" />

