### PR TITLE
DESNZ-2209 resolve govuk notify error

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -58,7 +58,7 @@ public class LocalAuthorityData
     // Avoid making manual changes to this code if possible
     public static readonly Dictionary<string, LocalAuthorityDetails> LocalAuthorityDetailsByCustodianCode = new()
     {
-        { "9051", new LocalAuthorityDetails("Aberdeen City Council", LocalAuthorityStatus.NoFunding, "https://www.aberdeencity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9051", new LocalAuthorityDetails("Aberdeen City Council", LocalAuthorityStatus.TakingFutureReferrals, "https://www.aberdeencity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
         { "9052", new LocalAuthorityDetails("Aberdeenshire Council", LocalAuthorityStatus.NoFunding, "https://www.aberdeenshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
         { "3805", new LocalAuthorityDetails("Adur District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
         { "1005", new LocalAuthorityDetails("Amber Valley Borough Council", LocalAuthorityStatus.Live, "https://www.ambervalley.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },

--- a/WhlgPublicWebsite.BusinessLogic/Models/ReferralRequest.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Models/ReferralRequest.cs
@@ -25,7 +25,8 @@ public class ReferralRequest : IEntityWithRowVersioning
         FullName = questionnaire.LaContactName;
         ContactEmailAddress = questionnaire.LaContactEmailAddress;
         ContactTelephone = questionnaire.LaContactTelephone;
-
+        
+        ReferralCode = questionnaire.ReferralCode;
         RequestDate = DateTime.Now;
         WasSubmittedToPendingLocalAuthority =
             questionnaire.LocalAuthorityStatus == LocalAuthorityData.LocalAuthorityStatus.Pending;
@@ -66,7 +67,7 @@ public class ReferralRequest : IEntityWithRowVersioning
 
     public ReferralRequestFollowUp? FollowUp { get; set; }
 
-    public string ReferralCode { get; set; }
+    public string? ReferralCode { get; set; }
 
     public uint Version { get; set; }
 

--- a/WhlgPublicWebsite.BusinessLogic/QuestionnaireUpdater.cs
+++ b/WhlgPublicWebsite.BusinessLogic/QuestionnaireUpdater.cs
@@ -219,19 +219,29 @@ public class QuestionnaireUpdater
 
         if (confirmationConsentGranted)
         {
-            if (questionnaire.LocalAuthorityStatus == LocalAuthorityData.LocalAuthorityStatus.Pending)
+            switch (questionnaire.LocalAuthorityStatus)
             {
-                emailSender.SendReferenceCodeEmailForPendingLocalAuthority(
-                    confirmationEmailAddress,
-                    questionnaire.LaContactName,
-                    new ReferralRequest(questionnaire));
-            }
-            else
-            {
-                emailSender.SendReferenceCodeEmailForLiveLocalAuthority(
-                    confirmationEmailAddress,
-                    questionnaire.LaContactName,
-                    new ReferralRequest(questionnaire));
+                case LocalAuthorityData.LocalAuthorityStatus.Pending:
+                    emailSender.SendReferenceCodeEmailForPendingLocalAuthority(
+                        confirmationEmailAddress,
+                        questionnaire.LaContactName,
+                        new ReferralRequest(questionnaire));
+                    break;
+                case LocalAuthorityData.LocalAuthorityStatus.TakingFutureReferrals:
+                    emailSender.SendReferenceCodeEmailForTakingFutureReferralsLocalAuthority(
+                        confirmationEmailAddress,
+                        questionnaire.LaContactName,
+                        new ReferralRequest(questionnaire));
+                    break;
+                case LocalAuthorityData.LocalAuthorityStatus.Live:
+                    emailSender.SendReferenceCodeEmailForLiveLocalAuthority(
+                        confirmationEmailAddress,
+                        questionnaire.LaContactName,
+                        new ReferralRequest(questionnaire));
+                    break;
+                default:
+                    throw new Exception(
+                        $"Local Authority status ({questionnaire.LocalAuthorityStatus}) should never get to this method as they should not recieve a confirmation email.");
             }
         }
 

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
@@ -13,7 +13,7 @@ internal static class LocalAuthorityStatuses
     {
         return new Dictionary<string, LocalAuthorityStatus>
         {
-            { "9051", NoFunding },
+            { "9051", TakingFutureReferrals },
             { "9052", NoFunding },
             { "3805", Live },
             { "1005", Live },

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/QuestionnaireUpdaterTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/QuestionnaireUpdaterTests.cs
@@ -38,9 +38,9 @@ public class QuestionnaireUpdaterTests
         pendingCustodianCode =
             LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus.Pending);
         // DESNZ-1849: Reinstate when an LA of takingFutureReferrals exists
-        // takingFutureReferralsCustodianCode =
-        //     LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus
-        //         .TakingFutureReferrals);
+        takingFutureReferralsCustodianCode =
+            LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus
+                .TakingFutureReferrals);
         mockEpcApi = new Mock<IEpcApi>();
         mockPostCodeService = new Mock<IEligiblePostcodeService>();
         mockDataAccessProvider = new Mock<IDataAccessProvider>();
@@ -324,7 +324,7 @@ public class QuestionnaireUpdaterTests
     }
 
     [Test]
-    [Ignore("DESNZ-1849: Reinstate when an LA of takingFutureReferrals exists")]
+    // [Ignore("DESNZ-1849: Reinstate when an LA of takingFutureReferrals exists")]
     public async Task
         GenerateReferralAsync_WhenCalledWithEmailAndLocalAuthorityIsTakingFutureReferrals_SendOneEmailWithReferralCodeWithTakingFutureReferralTemplate()
     {

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/QuestionFlowServiceTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/QuestionFlowServiceTests.cs
@@ -37,7 +37,7 @@ public class QuestionFlowServiceTests
     private static readonly string PendingCustodianCode =
         LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus.Pending);
     // DESNZ-1849: Reinstate when an LA of takingFutureReferrals exists
-    // private static readonly string TakingFutureReferralsCustodianCode = LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus.TakingFutureReferrals);
+    private static readonly string TakingFutureReferralsCustodianCode = LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus.TakingFutureReferrals);
 
     [TestCaseSource(nameof(BackTestCases))]
     public void RunBackLinkTestCases(QuestionFlowServiceTestCase testCase)
@@ -65,19 +65,19 @@ public class QuestionFlowServiceTests
         output.Should().Be(testCase.ExpectedOutput);
     }
 
-    [Test]
-    public void NoTakingFutureReferralsLasExist()
-    {
-        // If this test starts failing, the LA data has been updated and the statement in the test name is now false
-        // Do the following:
-        // 1. Update this test's name to reflect if this LocalAuthorityStatus exists within the LA data
-        // 2. Search the project for "DESNZ-1849" for all references to this status and ensure they are updated to reflect the test name statement
-        // 3. Invert the test assertion to correctly assert the statement in the test name (i.e. Throw should become NotThrow and vice versa)
-        Action act = () =>
-            LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus
-                .TakingFutureReferrals);
-        act.Should().Throw<InvalidOperationException>();
-    }
+    // [Test]
+    // public void NoTakingFutureReferralsLasExist()
+    // {
+    //     // If this test starts failing, the LA data has been updated and the statement in the test name is now false
+    //     // Do the following:
+    //     // 1. Update this test's name to reflect if this LocalAuthorityStatus exists within the LA data
+    //     // 2. Search the project for "DESNZ-1849" for all references to this status and ensure they are updated to reflect the test name statement
+    //     // 3. Invert the test assertion to correctly assert the statement in the test name (i.e. Throw should become NotThrow and vice versa)
+    //     Action act = () =>
+    //         LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus
+    //             .TakingFutureReferrals);
+    //     act.Should().Throw<InvalidOperationException>();
+    // }
 
     [Test]
     public void NoReferralsPausedLasExist()
@@ -628,13 +628,13 @@ public class QuestionFlowServiceTests
             ),
             QuestionFlowStep.Pending),
         // DESNZ-1849: Reinstate when an LA of takingFutureReferrals exists
-        // new(
-        //     "Check answers continues to taking future referrals if LA is taking future referrals",
-        //     new Input(
-        //         QuestionFlowStep.CheckAnswers,
-        //         custodianCode: TakingFutureReferralsCustodianCode
-        //     ),
-        //     QuestionFlowStep.TakingFutureReferrals),
+        new(
+            "Check answers continues to taking future referrals if LA is taking future referrals",
+            new Input(
+                QuestionFlowStep.CheckAnswers,
+                custodianCode: TakingFutureReferralsCustodianCode
+            ),
+            QuestionFlowStep.TakingFutureReferrals),
         new(
             "Pending continues to eligible",
             new Input(


### PR DESCRIPTION
[Link to Jira ticket](https://softwiretech.atlassian.net/browse/DESNZ-2209)

# Description

- Added ReferralCode as a nullable field on the ReferralRequest model and let it default to what the questionnaire has
- Added a path for TakingFutureReferrals in if this status is reintroduced
- Temporarily set Aberdeen to TakingFutureReferrals to test the ReferenceCode email logic
  - e6f1186521dd0d4d49904451c98fa5b8cb1e38af should be reverted before pushing to staging

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

## ReferralCode email
<img width="1294" height="1687" alt="{BA9CF03F-3388-460E-98CC-215EEF91D268}" src="https://github.com/user-attachments/assets/056d85b3-317d-4a66-9a79-785ee8b64934" />

## Database values are correct - i.e. No ContactEmailAddress is passed to the LocalAuthority
<img width="1431" height="240" alt="{211CB6B1-05BD-4652-A29E-0174D7A77EF8}" src="https://github.com/user-attachments/assets/af4b6fdc-e3b4-4ff7-90c9-03562ab38c35" />



