### PR TITLE
DESNZ-2200: Fixed inconsistent custom wordings

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/WhlgPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -6,338 +6,349 @@ using Notify.Exceptions;
 using Notify.Interfaces;
 using WhlgPublicWebsite.BusinessLogic.Models;
 
-namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
+namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending;
+
+public class GovUkNotifyApi(
+    INotificationClient client,
+    IOptions<GovUkNotifyConfiguration> config,
+    ILogger<GovUkNotifyApi> logger)
+    : IEmailSender
 {
-    public class GovUkNotifyApi(
-        INotificationClient client,
-        IOptions<GovUkNotifyConfiguration> config,
-        ILogger<GovUkNotifyApi> logger)
-        : IEmailSender
+    private readonly GovUkNotifyConfiguration govUkNotifyConfig = config.Value;
+
+    public void SendReferenceCodeEmailForLiveLocalAuthority
+    (
+        string emailAddress,
+        string recipientName,
+        ReferralRequest referralRequest)
     {
-        private readonly GovUkNotifyConfiguration govUkNotifyConfig = config.Value;
+        // Live LAs in WMCA are not required to meet SLA requirements and thus have a different email template
+        SendLiveReferenceCodeEmail(emailAddress, recipientName, referralRequest,
+            LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
+                ConsortiumNames.WestMidlandsCombinedAuthority)
+                ? govUkNotifyConfig.ReferenceCodeForLiveNo10DaySlaLocalAuthorityTemplate
+                : govUkNotifyConfig.ReferenceCodeForLiveLocalAuthorityTemplate);
+    }
 
-        private void SendEmail(GovUkNotifyEmailModel emailModel)
+    public void SendReferenceCodeEmailForTakingFutureReferralsLocalAuthority
+    (
+        string emailAddress,
+        string recipientName,
+        ReferralRequest referralRequest)
+    {
+        SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
+            govUkNotifyConfig.ReferenceCodeForTakingFutureReferralsLocalAuthorityTemplate);
+    }
+
+    public void SendReferenceCodeEmailForPendingLocalAuthority
+    (
+        string emailAddress,
+        string recipientName,
+        ReferralRequest referralRequest)
+    {
+        SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
+            govUkNotifyConfig.ReferenceCodeForPendingLocalAuthorityTemplate);
+    }
+
+    public void SendFollowUpEmail
+    (
+        ReferralRequest referralRequest,
+        string followUpLink
+    )
+    {
+        var template = govUkNotifyConfig.ReferralFollowUpTemplate;
+        LocalAuthorityData.LocalAuthorityDetails localAuthorityDetails;
+        try
         {
-            try
-            {
-                client.SendEmail(
-                    emailModel.EmailAddress,
-                    emailModel.TemplateId,
-                    emailModel.Personalisation,
-                    emailModel.Reference,
-                    emailModel.EmailReplyToId,
-                    emailModel.OneClickUnsubscribeUrl);
-            }
-            catch (NotifyClientException e)
-            {
-                if (e.Message.Contains("Not a valid email address"))
-                {
-                    logger.LogWarning("GOV.UK Notify could not send to an invalid email address");
-                }
-                else if (e.Message.Contains("send to this recipient using a team-only API key"))
-                {
-                    // In development we use a 'team-only' API key which can only send to team emails
-                    logger.LogWarning("GOV.UK Notify cannot send to this recipient using a team-only API key");
-                }
-                else
-                {
-                    logger.LogError(e, "GOV.UK Notify returned an error");
-                }
-            }
-        }
-
-        public void SendReferenceCodeEmailForLiveLocalAuthority
-        (
-            string emailAddress,
-            string recipientName,
-            ReferralRequest referralRequest)
-        {
-            // Live LAs in WMCA are not required to meet SLA requirements and thus have a different email template
-            SendLiveReferenceCodeEmail(emailAddress, recipientName, referralRequest,
-                LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
-                    ConsortiumNames.WestMidlandsCombinedAuthority)
-                    ? govUkNotifyConfig.ReferenceCodeForLiveNo10DaySlaLocalAuthorityTemplate
-                    : govUkNotifyConfig.ReferenceCodeForLiveLocalAuthorityTemplate);
-        }
-
-        public void SendReferenceCodeEmailForTakingFutureReferralsLocalAuthority
-        (
-            string emailAddress,
-            string recipientName,
-            ReferralRequest referralRequest)
-        {
-            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
-                govUkNotifyConfig.ReferenceCodeForTakingFutureReferralsLocalAuthorityTemplate);
-        }
-
-        public void SendReferenceCodeEmailForPendingLocalAuthority
-        (
-            string emailAddress,
-            string recipientName,
-            ReferralRequest referralRequest)
-        {
-            SendReferenceCodeEmail(emailAddress, recipientName, referralRequest,
-                govUkNotifyConfig.ReferenceCodeForPendingLocalAuthorityTemplate);
-        }
-
-        public void SendFollowUpEmail
-        (
-            ReferralRequest referralRequest,
-            string followUpLink
-        )
-        {
-            var template = govUkNotifyConfig.ReferralFollowUpTemplate;
-            LocalAuthorityData.LocalAuthorityDetails localAuthorityDetails;
-            try
-            {
-                localAuthorityDetails =
-                    LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
-
-                var personalisation = new Dictionary<string, dynamic>
-                {
-                    { template.RecipientNamePlaceholder, referralRequest.FullName },
-                    { template.ReferenceCodePlaceholder, referralRequest.ReferralCode },
-                    { template.LocalAuthorityNamePlaceholder, localAuthorityDetails.Name },
-                    { template.ReferralDatePlaceholder, referralRequest.RequestDate.ToString("dd/MM/yyyy") },
-                    { template.FollowUpLinkPlaceholder, followUpLink },
-                };
-                var emailModel = new GovUkNotifyEmailModel
-                {
-                    EmailAddress = referralRequest.ContactEmailAddress,
-                    TemplateId = template.Id,
-                    Personalisation = personalisation
-                };
-                SendEmail(emailModel);
-            }
-            catch (KeyNotFoundException ex)
-            {
-                logger.LogError
-                (
-                    ex,
-                    "Failed to send follow up email for referral request \"{referralRequest.Id}\" with invalid custodian code",
-                    referralRequest.Id
-                );
-            }
-        }
-
-        public void SendComplianceEmail(
-            MemoryStream recentReferralRequestOverviewFileData,
-            MemoryStream recentLocalAuthorityReferralRequestFollowUpFileData,
-            MemoryStream recentConsortiumReferralRequestFollowUpFileData,
-            MemoryStream historicLocalAuthorityReferralRequestFollowUpFileData,
-            MemoryStream historicConsortiumReferralRequestFollowUpFileData)
-        {
-            var recipientList = govUkNotifyConfig.ComplianceEmailRecipients;
-            var template = govUkNotifyConfig.ComplianceReportTemplate;
-            var personalisation = new Dictionary<string, dynamic>
-            {
-                { "OverviewFileLink", PrepareCsvUpload(recentReferralRequestOverviewFileData, "overview.csv") },
-                {
-                    "RecentLocalAuthorityFollowUpFileLink",
-                    PrepareCsvUpload(recentLocalAuthorityReferralRequestFollowUpFileData,
-                        "recent-local-authority-follow-up.csv")
-                },
-                {
-                    "RecentConsortiumFollowUpFileLink",
-                    PrepareCsvUpload(recentConsortiumReferralRequestFollowUpFileData, "recent-consortium-follow-up.csv")
-                },
-                {
-                    "HistoricLocalAuthorityFollowUpFileLink",
-                    PrepareCsvUpload(historicLocalAuthorityReferralRequestFollowUpFileData,
-                        "historic-local-authority-follow-up.csv")
-                },
-                {
-                    "HistoricConsortiumFollowUpFileLink",
-                    PrepareCsvUpload(historicConsortiumReferralRequestFollowUpFileData,
-                        "historic-consortium-follow-up.csv")
-                },
-            };
-            SendEmailToRecipients(recipientList, template.Id, personalisation);
-        }
-
-        public void SendPendingReferralReportEmail(MemoryStream pendingReferralRequestsFileData)
-        {
-            var recipientList = govUkNotifyConfig.PendingReferralEmailRecipients;
-            var template = govUkNotifyConfig.PendingReferralReportTemplate;
-            var personalisation = new Dictionary<string, dynamic>
-            {
-                {
-                    template.LinkPlaceholder,
-                    PrepareCsvUpload(pendingReferralRequestsFileData, "pending-referral-requests.csv")
-                },
-            };
-            SendEmailToRecipients(recipientList, template.Id, personalisation);
-        }
-
-        private void SendReferenceCodeEmail
-        (
-            string emailAddress,
-            string recipientName,
-            ReferralRequest referralRequest,
-            ReferenceCodeConfiguration template)
-        {
-            var localAuthorityDetails = GetLocalAuthorityDetails(referralRequest);
+            localAuthorityDetails =
+                LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
 
             var personalisation = new Dictionary<string, dynamic>
             {
-                { template.RecipientNamePlaceholder, recipientName },
+                { template.RecipientNamePlaceholder, referralRequest.FullName },
                 { template.ReferenceCodePlaceholder, referralRequest.ReferralCode },
                 { template.LocalAuthorityNamePlaceholder, localAuthorityDetails.Name },
-                { template.LocalAuthorityWebsiteUrlPlaceholder, localAuthorityDetails.WebsiteUrl }
+                { template.ReferralDatePlaceholder, referralRequest.RequestDate.ToString("dd/MM/yyyy") },
+                { template.FollowUpLinkPlaceholder, followUpLink }
             };
             var emailModel = new GovUkNotifyEmailModel
             {
-                EmailAddress = emailAddress,
+                EmailAddress = referralRequest.ContactEmailAddress,
                 TemplateId = template.Id,
                 Personalisation = personalisation
             };
             SendEmail(emailModel);
         }
-
-        private void SendLiveReferenceCodeEmail
-        (
-            string emailAddress,
-            string recipientName,
-            ReferralRequest referralRequest,
-            LiveReferenceCodeConfiguration template)
+        catch (KeyNotFoundException ex)
         {
-            var localAuthorityDetails = GetLocalAuthorityDetails(referralRequest);
-
-            var personalisation = new Dictionary<string, dynamic>
-            {
-                { template.RecipientNamePlaceholder, recipientName },
-                { template.ReferenceCodePlaceholder, referralRequest.ReferralCode },
-                { template.TitleDeliveryPartnerPlaceholder, localAuthorityDetails.Name },
-                {
-                    template.TitleDeliveryPartnerOrContractorPlaceholder,
-                    localAuthorityDetails.Name + " or their official contractor"
-                },
-                {
-                    template.YourDeliveryPartnerOrContractorPlaceholder,
-                    "Your Local Authority or their official contractor"
-                },
-                { template.WebsiteNamePlaceholder, localAuthorityDetails.Name + " website" },
-                { template.WebsiteUrlPlaceholder, localAuthorityDetails.WebsiteUrl }
-            };
-
-            // LA specific overrides
-            if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
-                    ConsortiumNames.PortsmouthCityCouncil))
-            {
-                personalisation[template.TitleDeliveryPartnerPlaceholder] = localAuthorityDetails.Name +
-                                                                            "'s official delivery partner: Warmer Homes";
-                personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
-                    localAuthorityDetails.Name + "'s official delivery partner: Warmer Homes";
-                personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] = localAuthorityDetails.Name +
-                    "'s official delivery partner: Warmer Homes";
-                personalisation[template.WebsiteNamePlaceholder] = "Warmer Homes website";
-                personalisation[template.WebsiteUrlPlaceholder] = "https://www.warmerhomes.org.uk";
-            }
-
-            if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
-                    ConsortiumNames.OxfordshireCountyCouncil))
-            {
-                personalisation[template.TitleDeliveryPartnerPlaceholder] = "Oxfordshire County Council";
-                personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
-                    "Oxfordshire County Council or their official contractor";
-                personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] =
-                    "Oxfordshire County Council or their official contractor";
-                personalisation[template.WebsiteNamePlaceholder] = "Oxfordshire County Council website";
-                personalisation[template.WebsiteUrlPlaceholder] =
-                    "https://www.oxfordshire.gov.uk/residents/environment-and-planning/energy-and-climate-change/retrofitting-your-home/retrofit-help-you";
-            }
-
-            if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
-                    ConsortiumNames.GreaterLondonAuthority))
-            {
-                personalisation[template.TitleDeliveryPartnerPlaceholder] = "Greater London Authority";
-                personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
-                    "Greater London Authority or their official contractor";
-                personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] =
-                    "Greater London Authority or their official contractor";
-                personalisation[template.WebsiteNamePlaceholder] = "Greater London Authority website";
-                personalisation[template.WebsiteUrlPlaceholder] =
-                    "https://www.london.gov.uk/programmes-strategies/environment-and-climate-change/net-zero-energy/warmer-homes";
-            }
-
-            if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
-                    ConsortiumNames.BroadlandDistrictCouncil))
-            {
-                personalisation[template.WebsiteNamePlaceholder] = "Norfolk Warm Homes website";
-            }
-
-            var emailModel = new GovUkNotifyEmailModel
-            {
-                EmailAddress = emailAddress,
-                TemplateId = template.Id,
-                Personalisation = personalisation
-            };
-            SendEmail(emailModel);
-        }
-
-        private LocalAuthorityData.LocalAuthorityDetails GetLocalAuthorityDetails(ReferralRequest referralRequest)
-        {
-            LocalAuthorityData.LocalAuthorityDetails localAuthorityDetails;
-            try
-            {
-                localAuthorityDetails =
-                    LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
-            }
-            catch (KeyNotFoundException ex)
-            {
-                logger.LogError
-                (
-                    ex,
-                    "Attempted to send reference code email with invalid custodian code \"{CustodianCode}\"",
-                    referralRequest.CustodianCode
-                );
-                throw new ArgumentOutOfRangeException
-                (
-                    $"Attempted to send reference code email with invalid custodian code \"{referralRequest.CustodianCode}\"",
-                    ex
-                );
-            }
-
-            return localAuthorityDetails;
-        }
-
-        private static JObject PrepareCsvUpload(MemoryStream csvData, string name)
-        {
-            var datePrefix = DateTime.Now.ToString("yyyyMMdd");
-            return NotificationClient.PrepareUpload(csvData.ToArray(), $"{datePrefix}-{name}");
-        }
-
-        private void SendEmailToRecipients(
-            string recipientList,
-            string templateId,
-            Dictionary<string, dynamic> personalisation)
-        {
-            if (string.IsNullOrEmpty(recipientList))
-            {
-                return;
-            }
-
-            var emailAddresses = recipientList.Split(",").Select(emailAddress => emailAddress.Trim());
-            foreach (var emailAddress in emailAddresses)
-            {
-                var emailModel = new GovUkNotifyEmailModel
-                {
-                    EmailAddress = emailAddress,
-                    TemplateId = templateId,
-                    Personalisation = personalisation
-                };
-                SendEmail(emailModel);
-            }
+            logger.LogError
+            (
+                ex,
+                "Failed to send follow up email for referral request \"{referralRequest.Id}\" with invalid custodian code",
+                referralRequest.Id
+            );
         }
     }
 
-    internal class GovUkNotifyEmailModel
+    public void SendComplianceEmail(
+        MemoryStream recentReferralRequestOverviewFileData,
+        MemoryStream recentLocalAuthorityReferralRequestFollowUpFileData,
+        MemoryStream recentConsortiumReferralRequestFollowUpFileData,
+        MemoryStream historicLocalAuthorityReferralRequestFollowUpFileData,
+        MemoryStream historicConsortiumReferralRequestFollowUpFileData)
     {
-        public string EmailAddress { get; init; }
-        public string TemplateId { get; init; }
-        public Dictionary<string, dynamic> Personalisation { get; init; }
-        public string Reference { get; set; }
-        public string EmailReplyToId { get; set; }
-        public string OneClickUnsubscribeUrl { get; set; }
+        var recipientList = govUkNotifyConfig.ComplianceEmailRecipients;
+        var template = govUkNotifyConfig.ComplianceReportTemplate;
+        var personalisation = new Dictionary<string, dynamic>
+        {
+            { "OverviewFileLink", PrepareCsvUpload(recentReferralRequestOverviewFileData, "overview.csv") },
+            {
+                "RecentLocalAuthorityFollowUpFileLink",
+                PrepareCsvUpload(recentLocalAuthorityReferralRequestFollowUpFileData,
+                    "recent-local-authority-follow-up.csv")
+            },
+            {
+                "RecentConsortiumFollowUpFileLink",
+                PrepareCsvUpload(recentConsortiumReferralRequestFollowUpFileData, "recent-consortium-follow-up.csv")
+            },
+            {
+                "HistoricLocalAuthorityFollowUpFileLink",
+                PrepareCsvUpload(historicLocalAuthorityReferralRequestFollowUpFileData,
+                    "historic-local-authority-follow-up.csv")
+            },
+            {
+                "HistoricConsortiumFollowUpFileLink",
+                PrepareCsvUpload(historicConsortiumReferralRequestFollowUpFileData,
+                    "historic-consortium-follow-up.csv")
+            }
+        };
+        SendEmailToRecipients(recipientList, template.Id, personalisation);
     }
+
+    public void SendPendingReferralReportEmail(MemoryStream pendingReferralRequestsFileData)
+    {
+        var recipientList = govUkNotifyConfig.PendingReferralEmailRecipients;
+        var template = govUkNotifyConfig.PendingReferralReportTemplate;
+        var personalisation = new Dictionary<string, dynamic>
+        {
+            {
+                template.LinkPlaceholder,
+                PrepareCsvUpload(pendingReferralRequestsFileData, "pending-referral-requests.csv")
+            }
+        };
+        SendEmailToRecipients(recipientList, template.Id, personalisation);
+    }
+
+    private void SendEmail(GovUkNotifyEmailModel emailModel)
+    {
+        try
+        {
+            client.SendEmail(
+                emailModel.EmailAddress,
+                emailModel.TemplateId,
+                emailModel.Personalisation,
+                emailModel.Reference,
+                emailModel.EmailReplyToId,
+                emailModel.OneClickUnsubscribeUrl);
+        }
+        catch (NotifyClientException e)
+        {
+            if (e.Message.Contains("Not a valid email address"))
+            {
+                logger.LogWarning("GOV.UK Notify could not send to an invalid email address");
+            }
+            else if (e.Message.Contains("send to this recipient using a team-only API key"))
+            {
+                // In development we use a 'team-only' API key which can only send to team emails
+                logger.LogWarning("GOV.UK Notify cannot send to this recipient using a team-only API key");
+            }
+            else
+            {
+                logger.LogError(e, "GOV.UK Notify returned an error");
+            }
+        }
+    }
+
+    private void SendReferenceCodeEmail
+    (
+        string emailAddress,
+        string recipientName,
+        ReferralRequest referralRequest,
+        ReferenceCodeConfiguration template)
+    {
+        var localAuthorityDetails = GetLocalAuthorityDetails(referralRequest);
+
+        var personalisation = new Dictionary<string, dynamic>
+        {
+            { template.RecipientNamePlaceholder, recipientName },
+            { template.ReferenceCodePlaceholder, referralRequest.ReferralCode },
+            { template.LocalAuthorityNamePlaceholder, localAuthorityDetails.Name },
+            { template.LocalAuthorityWebsiteUrlPlaceholder, localAuthorityDetails.WebsiteUrl }
+        };
+        var emailModel = new GovUkNotifyEmailModel
+        {
+            EmailAddress = emailAddress,
+            TemplateId = template.Id,
+            Personalisation = personalisation
+        };
+        SendEmail(emailModel);
+    }
+
+    private void SendLiveReferenceCodeEmail
+    (
+        string emailAddress,
+        string recipientName,
+        ReferralRequest referralRequest,
+        LiveReferenceCodeConfiguration template)
+    {
+        var localAuthorityDetails = GetLocalAuthorityDetails(referralRequest);
+
+        var personalisation = new Dictionary<string, dynamic>
+        {
+            { template.RecipientNamePlaceholder, recipientName },
+            { template.ReferenceCodePlaceholder, referralRequest.ReferralCode },
+            { template.TitleDeliveryPartnerPlaceholder, localAuthorityDetails.Name },
+            {
+                template.TitleDeliveryPartnerOrContractorPlaceholder,
+                localAuthorityDetails.Name + " or their official contractor"
+            },
+            {
+                template.YourDeliveryPartnerOrContractorPlaceholder,
+                "Your Local Authority or their official contractor"
+            },
+            { template.WebsiteNamePlaceholder, localAuthorityDetails.Name + " website" },
+            { template.WebsiteUrlPlaceholder, localAuthorityDetails.WebsiteUrl }
+        };
+
+        // LA specific overrides
+        if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
+                ConsortiumNames.PortsmouthCityCouncil))
+        {
+            personalisation[template.TitleDeliveryPartnerPlaceholder] = localAuthorityDetails.Name +
+                                                                        "'s official delivery partner: Warmer Homes";
+            personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
+                localAuthorityDetails.Name + "'s official delivery partner: Warmer Homes";
+            personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] = localAuthorityDetails.Name +
+                "'s official delivery partner: Warmer Homes";
+            personalisation[template.WebsiteNamePlaceholder] = "Warmer Homes website";
+            personalisation[template.WebsiteUrlPlaceholder] = "https://www.warmerhomes.org.uk";
+        }
+
+        if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
+                ConsortiumNames.OxfordshireCountyCouncil))
+        {
+            personalisation[template.TitleDeliveryPartnerPlaceholder] = "Oxfordshire County Council";
+            personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
+                "Oxfordshire County Council or their official contractor";
+            personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] =
+                "Oxfordshire County Council or their official contractor";
+            personalisation[template.WebsiteNamePlaceholder] = "Oxfordshire County Council website";
+            personalisation[template.WebsiteUrlPlaceholder] =
+                "https://www.oxfordshire.gov.uk/residents/environment-and-planning/energy-and-climate-change/retrofitting-your-home/retrofit-help-you";
+        }
+
+        if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
+                ConsortiumNames.GreaterLondonAuthority))
+        {
+            personalisation[template.TitleDeliveryPartnerPlaceholder] = "Greater London Authority";
+            personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
+                "Greater London Authority or their official contractor";
+            personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] =
+                "Greater London Authority or their official contractor";
+            personalisation[template.WebsiteNamePlaceholder] = "Greater London Authority website";
+            personalisation[template.WebsiteUrlPlaceholder] =
+                "https://www.london.gov.uk/programmes-strategies/environment-and-climate-change/net-zero-energy/warmer-homes";
+        }
+
+        if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
+                ConsortiumNames.BroadlandDistrictCouncil))
+        {
+            personalisation[template.WebsiteNamePlaceholder] = "Norfolk Warm Homes website";
+        }
+
+        if (LocalAuthorityData.CustodianCodeIsManagedByLcrca(referralRequest.CustodianCode))
+        {
+            personalisation[template.TitleDeliveryPartnerPlaceholder] = "Liverpool City Region Combined Authority";
+            personalisation[template.TitleDeliveryPartnerOrContractorPlaceholder] =
+                "Liverpool City Region Combined Authority or their official contractor";
+            personalisation[template.YourDeliveryPartnerOrContractorPlaceholder] =
+                "Liverpool City Region Combined Authority or their official contractor";
+            personalisation[template.WebsiteNamePlaceholder] = "Liverpool City Region Combined Authority website";
+            personalisation[template.WebsiteUrlPlaceholder] =
+                "https://www.liverpoolcityregion-ca.gov.uk/warm-homes-local-grant";
+        }
+
+        var emailModel = new GovUkNotifyEmailModel
+        {
+            EmailAddress = emailAddress,
+            TemplateId = template.Id,
+            Personalisation = personalisation
+        };
+        SendEmail(emailModel);
+    }
+
+    private LocalAuthorityData.LocalAuthorityDetails GetLocalAuthorityDetails(ReferralRequest referralRequest)
+    {
+        LocalAuthorityData.LocalAuthorityDetails localAuthorityDetails;
+        try
+        {
+            localAuthorityDetails =
+                LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[referralRequest.CustodianCode];
+        }
+        catch (KeyNotFoundException ex)
+        {
+            logger.LogError
+            (
+                ex,
+                "Attempted to send reference code email with invalid custodian code \"{CustodianCode}\"",
+                referralRequest.CustodianCode
+            );
+            throw new ArgumentOutOfRangeException
+            (
+                $"Attempted to send reference code email with invalid custodian code \"{referralRequest.CustodianCode}\"",
+                ex
+            );
+        }
+
+        return localAuthorityDetails;
+    }
+
+    private static JObject PrepareCsvUpload(MemoryStream csvData, string name)
+    {
+        var datePrefix = DateTime.Now.ToString("yyyyMMdd");
+        return NotificationClient.PrepareUpload(csvData.ToArray(), $"{datePrefix}-{name}");
+    }
+
+    private void SendEmailToRecipients(
+        string recipientList,
+        string templateId,
+        Dictionary<string, dynamic> personalisation)
+    {
+        if (string.IsNullOrEmpty(recipientList))
+        {
+            return;
+        }
+
+        var emailAddresses = recipientList.Split(",").Select(emailAddress => emailAddress.Trim());
+        foreach (var emailAddress in emailAddresses)
+        {
+            var emailModel = new GovUkNotifyEmailModel
+            {
+                EmailAddress = emailAddress,
+                TemplateId = templateId,
+                Personalisation = personalisation
+            };
+            SendEmail(emailModel);
+        }
+    }
+}
+
+internal class GovUkNotifyEmailModel
+{
+    public string EmailAddress { get; init; }
+    public string TemplateId { get; init; }
+    public Dictionary<string, dynamic> Personalisation { get; init; }
+    public string Reference { get; set; }
+    public string EmailReplyToId { get; set; }
+    public string OneClickUnsubscribeUrl { get; set; }
 }

--- a/WhlgPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
+++ b/WhlgPublicWebsite.BusinessLogic/ExternalServices/EmailSending/GovUkNotifyApi.cs
@@ -260,6 +260,12 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.EmailSending
                     "https://www.london.gov.uk/programmes-strategies/environment-and-climate-change/net-zero-energy/warmer-homes";
             }
 
+            if (LocalAuthorityData.CustodianCodeIsInConsortium(referralRequest.CustodianCode,
+                    ConsortiumNames.BroadlandDistrictCouncil))
+            {
+                personalisation[template.WebsiteNamePlaceholder] = "Norfolk Warm Homes website";
+            }
+
             var emailModel = new GovUkNotifyEmailModel
             {
                 EmailAddress = emailAddress,

--- a/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -32,7 +32,7 @@ public class LocalAuthorityData
         { IncomeThreshold._36000, new[] { IncomeBand.UnderOrEqualTo36000, IncomeBand.GreaterThan36000 } }
     };
 
-    private static IEnumerable<string> FilterCustodianCodes(
+    public static IEnumerable<string> FilterCustodianCodes(
         string consortium,
         LocalAuthorityStatus? status = null)
     {
@@ -427,6 +427,8 @@ public class LocalAuthorityData
                localAuthority.Consortium == consortium;
     }
 
+    public static readonly IReadOnlyList<string> ManagedByLcrcaCodes = new[] { "650", "4305", "4315", "4325" };
+    
     public static bool CustodianCodeIsManagedByLcrca(string custodianCode)
     {
         return 
@@ -436,6 +438,6 @@ public class LocalAuthorityData
             // Knowsley
             // St Helens
             // Wirral
-            && custodianCode is "650" or "4305" or "4315" or "4325";
+            && ManagedByLcrcaCodes.Contains(custodianCode);
     }
 }

--- a/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -15,34 +15,10 @@ public class LocalAuthorityData
         Live
     }
 
-    public record LocalAuthorityDetails(
-        string Name,
-        LocalAuthorityStatus Status,
-        string WebsiteUrl,
-        IncomeBand[] IncomeBandOptions,
-        string? Consortium);
-
-    private enum IncomeThreshold
-    {
-        _36000
-    }
-
     private static readonly Dictionary<IncomeThreshold, IncomeBand[]> IncomeBandOptions = new()
     {
         { IncomeThreshold._36000, new[] { IncomeBand.UnderOrEqualTo36000, IncomeBand.GreaterThan36000 } }
     };
-
-    public static IEnumerable<string> FilterCustodianCodes(
-        string consortium,
-        LocalAuthorityStatus? status = null)
-    {
-        return LocalAuthorityDetailsByCustodianCode
-            .Where(localAuthority =>
-                localAuthority.Value.Consortium == consortium &&
-                (status == null || localAuthority.Value.Status == status))
-            .Select(localAuthority => localAuthority.Key)
-            .ToList();
-    }
 
     // The list of custodian codes comes from the publicly available "Local custodian codes" download link
     // on https://docs.os.uk/os-downloads/addressing-and-location/addressbase-core-principles/addressbase-local-custodian-codes
@@ -58,368 +34,1874 @@ public class LocalAuthorityData
     // Avoid making manual changes to this code if possible
     public static readonly Dictionary<string, LocalAuthorityDetails> LocalAuthorityDetailsByCustodianCode = new()
     {
-        { "9051", new LocalAuthorityDetails("Aberdeen City Council", LocalAuthorityStatus.NoFunding, "https://www.aberdeencity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9052", new LocalAuthorityDetails("Aberdeenshire Council", LocalAuthorityStatus.NoFunding, "https://www.aberdeenshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3805", new LocalAuthorityDetails("Adur District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1005", new LocalAuthorityDetails("Amber Valley Borough Council", LocalAuthorityStatus.Live, "https://www.ambervalley.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "9053", new LocalAuthorityDetails("Angus Council", LocalAuthorityStatus.NoFunding, "https://www.angus.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9054", new LocalAuthorityDetails("Argyll and Bute Council", LocalAuthorityStatus.NoFunding, "https://www.argyll-bute.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3810", new LocalAuthorityDetails("Arun District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "3005", new LocalAuthorityDetails("Ashfield District Council", LocalAuthorityStatus.Live, "https://www.ashfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
-        { "2205", new LocalAuthorityDetails("Ashford Borough Council", LocalAuthorityStatus.Live, "https://www.ashford.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3505", new LocalAuthorityDetails("Babergh District Council", LocalAuthorityStatus.Live, "https://www.babergh.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "5090", new LocalAuthorityDetails("Barnet Council", LocalAuthorityStatus.Live, "https://www.barnet.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "4405", new LocalAuthorityDetails("Barnsley Metropolitan Borough Council", LocalAuthorityStatus.Live, "https://www.barnsley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1505", new LocalAuthorityDetails("Basildon Council", LocalAuthorityStatus.Live, "https://www.basildon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1705", new LocalAuthorityDetails("Basingstoke and Deane Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "3010", new LocalAuthorityDetails("Bassetlaw District Council", LocalAuthorityStatus.Live, "https://www.bassetlaw.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "114", new LocalAuthorityDetails("Bath and North East Somerset Council", LocalAuthorityStatus.Live, "https://www.bathnes.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council") },
-        { "235", new LocalAuthorityDetails("Bedford Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "4605", new LocalAuthorityDetails("Birmingham City Council", LocalAuthorityStatus.Live, "https://www.birmingham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "2405", new LocalAuthorityDetails("Blaby District Council", LocalAuthorityStatus.Live, "https://www.blaby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
-        { "2372", new LocalAuthorityDetails("Blackburn with Darwen Borough Council", LocalAuthorityStatus.Live, "https://www.blackburn.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "2373", new LocalAuthorityDetails("Blackpool Council", LocalAuthorityStatus.Live, "https://www.blackpool.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "6910", new LocalAuthorityDetails("Blaenau Gwent County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.blaenau-gwent.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1010", new LocalAuthorityDetails("Bolsover District Council", LocalAuthorityStatus.Live, "https://www.bolsover.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "4205", new LocalAuthorityDetails("Bolton Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.bolton.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "2635", new LocalAuthorityDetails("Borough Council of King's Lynn & West Norfolk", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
-        { "1905", new LocalAuthorityDetails("Borough of Broxbourne Council", LocalAuthorityStatus.Live, "https://www.broxbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2505", new LocalAuthorityDetails("Boston Borough Council", LocalAuthorityStatus.Live, "https://www.boston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council") },
-        { "1260", new LocalAuthorityDetails("Bournemouth, Christchurch and Poole Council", LocalAuthorityStatus.ReferralsPaused, "https://www.bcpcouncil.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dorset Council") },
-        { "335", new LocalAuthorityDetails("Bracknell Forest Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1510", new LocalAuthorityDetails("Braintree District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.braintree.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "2605", new LocalAuthorityDetails("Breckland District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
-        { "5150", new LocalAuthorityDetails("Brent Council", LocalAuthorityStatus.Live, "https://www.brent.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "1515", new LocalAuthorityDetails("Brentwood Council", LocalAuthorityStatus.ReferralsPaused, "https://www.brentwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "6915", new LocalAuthorityDetails("Bridgend County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.bridgend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1445", new LocalAuthorityDetails("Brighton and Hove City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "116", new LocalAuthorityDetails("Bristol City Council", LocalAuthorityStatus.Live, "https://www.bristol.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council") },
-        { "2610", new LocalAuthorityDetails("Broadland District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
-        { "1805", new LocalAuthorityDetails("Bromsgrove District Council", LocalAuthorityStatus.Live, "https://www.bromsgrove.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "3015", new LocalAuthorityDetails("Broxtowe Borough Council", LocalAuthorityStatus.Live, "https://www.broxtowe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
-        { "440", new LocalAuthorityDetails("Buckinghamshire Council", LocalAuthorityStatus.Live, "https://www.buckinghamshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2315", new LocalAuthorityDetails("Burnley Borough Council", LocalAuthorityStatus.Live, "https://burnley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "4210", new LocalAuthorityDetails("Bury Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.bury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "6920", new LocalAuthorityDetails("Caerphilly County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.caerphilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4710", new LocalAuthorityDetails("Calderdale Council", LocalAuthorityStatus.Live, "https://new.calderdale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "505", new LocalAuthorityDetails("Cambridge City Council", LocalAuthorityStatus.Live, "https://www.cambridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
-        { "3405", new LocalAuthorityDetails("Cannock Chase District Council", LocalAuthorityStatus.Live, "https://www.cannockchasedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "2210", new LocalAuthorityDetails("Canterbury City Council", LocalAuthorityStatus.Live, "https://www.canterbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6825", new LocalAuthorityDetails("Carmarthenshire County Council", LocalAuthorityStatus.NoFunding, "https://www.carmarthenshire.gov.wales/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1520", new LocalAuthorityDetails("Castle Point District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.castlepoint.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "240", new LocalAuthorityDetails("Central Bedfordshire Council", LocalAuthorityStatus.Pending, "https://www.centralbedfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6820", new LocalAuthorityDetails("Ceredigion County Council", LocalAuthorityStatus.NoFunding, "https://www.ceredigion.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2410", new LocalAuthorityDetails("Charnwood Borough Council", LocalAuthorityStatus.Live, "https://www.charnwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
-        { "1525", new LocalAuthorityDetails("Chelmsford City Council", LocalAuthorityStatus.ReferralsPaused, "https://www.chelmsford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "1605", new LocalAuthorityDetails("Cheltenham Borough Council", LocalAuthorityStatus.Live, "https://www.cheltenham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "3105", new LocalAuthorityDetails("Cherwell District Council", LocalAuthorityStatus.Live, "https://www.cherwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
-        { "660", new LocalAuthorityDetails("Cheshire East Council", LocalAuthorityStatus.Live, "https://www.cheshireeast.gov.uk/home.aspx", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council") },
-        { "665", new LocalAuthorityDetails("Cheshire West and Chester Council", LocalAuthorityStatus.Live, "https://www.cheshirewestandchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council") },
-        { "1015", new LocalAuthorityDetails("Chesterfield Borough Council", LocalAuthorityStatus.Live, "https://www.chesterfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "3815", new LocalAuthorityDetails("Chichester District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "2320", new LocalAuthorityDetails("Chorley Borough Council", LocalAuthorityStatus.Live, "https://chorley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "6855", new LocalAuthorityDetails("City and County of Swansea Council", LocalAuthorityStatus.NoFunding, "https://www.swansea.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4705", new LocalAuthorityDetails("City of Bradford Metropolitan District Council", LocalAuthorityStatus.Pending, "https://www.bradford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6815", new LocalAuthorityDetails("City of Cardiff Council", LocalAuthorityStatus.NoFunding, "https://www.cardiff.gov.uk/ENG/Pages/default.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4410", new LocalAuthorityDetails("City of Doncaster Council", LocalAuthorityStatus.Live, "https://www.doncaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9064", new LocalAuthorityDetails("City of Edinburgh Council", LocalAuthorityStatus.NoFunding, "https://www.edinburgh.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "5030", new LocalAuthorityDetails("City of London Corporation", LocalAuthorityStatus.Live, "https://www.cityoflondon.gov.uk/about-us", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "2741", new LocalAuthorityDetails("City of York Council", LocalAuthorityStatus.Live, "https://www.york.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9056", new LocalAuthorityDetails("Clackmannanshire Council", LocalAuthorityStatus.NoFunding, "https://www.clacks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1530", new LocalAuthorityDetails("Colchester City Council", LocalAuthorityStatus.ReferralsPaused, "https://www.colchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "9020", new LocalAuthorityDetails("Comhairle nan Eilean Siar", LocalAuthorityStatus.NoFunding, "https://www.cne-siar.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6905", new LocalAuthorityDetails("Conwy County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.conwy.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "840", new LocalAuthorityDetails("Cornwall Council", LocalAuthorityStatus.Live, "https://www.cornwall.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council") },
-        { "1610", new LocalAuthorityDetails("Cotswold District Council", LocalAuthorityStatus.Live, "https://www.cotswold.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "4610", new LocalAuthorityDetails("Coventry City Council", LocalAuthorityStatus.Live, "https://www.coventry.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "3820", new LocalAuthorityDetails("Crawley Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "5240", new LocalAuthorityDetails("Croydon Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "940", new LocalAuthorityDetails("Cumberland Council", LocalAuthorityStatus.Live, "https://www.cumberland.gov.uk/housing/warm-homes/warm-homes-local-grant", IncomeBandOptions[IncomeThreshold._36000], "Westmorland and Furness Council") },
-        { "1910", new LocalAuthorityDetails("Dacorum Borough Council", LocalAuthorityStatus.Live, "https://www.dacorum.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1350", new LocalAuthorityDetails("Darlington Borough Council", LocalAuthorityStatus.Live, "https://www.darlington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
-        { "2215", new LocalAuthorityDetails("Dartford Borough Council", LocalAuthorityStatus.Live, "https://www.dartford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dover District Council") },
-        { "6830", new LocalAuthorityDetails("Denbighshire County Council", LocalAuthorityStatus.NoFunding, "https://www.denbighshire.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1055", new LocalAuthorityDetails("Derby City Council", LocalAuthorityStatus.Live, "https://www.derby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "1045", new LocalAuthorityDetails("Derbyshire Dales District Council", LocalAuthorityStatus.Live, "https://www.derbyshiredales.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "1155", new LocalAuthorityDetails("Devon County Council", LocalAuthorityStatus.Live, "https://www.devon.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "1265", new LocalAuthorityDetails("Dorset Council", LocalAuthorityStatus.ReferralsPaused, "https://www.dorsetcouncil.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dorset Council") },
-        { "2220", new LocalAuthorityDetails("Dover District Council", LocalAuthorityStatus.Live, "https://www.dover.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000], "Dover District Council") },
-        { "4615", new LocalAuthorityDetails("Dudley Borough Council", LocalAuthorityStatus.Live, "https://www.dudley.gov.uk/residents/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "9058", new LocalAuthorityDetails("Dumfries and Galloway Council", LocalAuthorityStatus.NoFunding, "https://www.dumfriesandgalloway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9059", new LocalAuthorityDetails("Dundee City Council", LocalAuthorityStatus.NoFunding, "https://www.dundeecity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1355", new LocalAuthorityDetails("Durham County Council", LocalAuthorityStatus.Live, "https://www.durham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "5270", new LocalAuthorityDetails("Ealing Council", LocalAuthorityStatus.Live, "https://www.ealing.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "9060", new LocalAuthorityDetails("East Ayrshire Council", LocalAuthorityStatus.NoFunding, "https://www.east-ayrshire.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "510", new LocalAuthorityDetails("East Cambridgeshire District Council", LocalAuthorityStatus.Live, "https://eastcambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
-        { "1105", new LocalAuthorityDetails("East Devon District Council", LocalAuthorityStatus.Live, "https://eastdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "9061", new LocalAuthorityDetails("East Dunbartonshire Council", LocalAuthorityStatus.NoFunding, "https://www.eastdunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1710", new LocalAuthorityDetails("East Hampshire District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1915", new LocalAuthorityDetails("East Hertfordshire District Council", LocalAuthorityStatus.Live, "https://www.eastherts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2510", new LocalAuthorityDetails("East Lindsey District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.e-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council") },
-        { "9062", new LocalAuthorityDetails("East Lothian Council", LocalAuthorityStatus.NoFunding, "https://www.eastlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9063", new LocalAuthorityDetails("East Renfrewshire Council", LocalAuthorityStatus.NoFunding, "https://www.eastrenfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2001", new LocalAuthorityDetails("East Riding of Yorkshire Council", LocalAuthorityStatus.ReferralsPaused, "https://www.eastriding.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3410", new LocalAuthorityDetails("East Staffordshire Borough Council", LocalAuthorityStatus.Live, "https://www.eaststaffsbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "3540", new LocalAuthorityDetails("East Suffolk Council", LocalAuthorityStatus.Live, "https://www.eastsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "1440", new LocalAuthorityDetails("East Sussex County Council", LocalAuthorityStatus.Live, "https://www.eastsussex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
-        { "1410", new LocalAuthorityDetails("Eastbourne Borough Council", LocalAuthorityStatus.Live, "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
-        { "1715", new LocalAuthorityDetails("Eastleigh Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "3605", new LocalAuthorityDetails("Elmbridge Borough Council", LocalAuthorityStatus.Live, "https://www.elmbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "5300", new LocalAuthorityDetails("Enfield Council", LocalAuthorityStatus.Live, "https://www.enfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "1535", new LocalAuthorityDetails("Epping Forest District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.eppingforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "3610", new LocalAuthorityDetails("Epsom and Ewell Borough Council", LocalAuthorityStatus.Live, "https://www.epsom-ewell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "1025", new LocalAuthorityDetails("Erewash Borough Council", LocalAuthorityStatus.Live, "https://www.erewash.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "1585", new LocalAuthorityDetails("Essex County Council", LocalAuthorityStatus.ReferralsPaused, "https://www.essex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "1110", new LocalAuthorityDetails("Exeter City Council", LocalAuthorityStatus.Live, "https://exeter.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "9065", new LocalAuthorityDetails("Falkirk Council", LocalAuthorityStatus.NoFunding, "https://www.falkirk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1720", new LocalAuthorityDetails("Fareham Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "515", new LocalAuthorityDetails("Fenland District Council", LocalAuthorityStatus.Live, "https://www.fenland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
-        { "9066", new LocalAuthorityDetails("Fife Council", LocalAuthorityStatus.NoFunding, "https://www.fife.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6835", new LocalAuthorityDetails("Flintshire County Council", LocalAuthorityStatus.NoFunding, "https://www.flintshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2250", new LocalAuthorityDetails("Folkestone and Hythe District Council", LocalAuthorityStatus.NoFunding, "https://www.folkestone-hythe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1615", new LocalAuthorityDetails("Forest of Dean District Council", LocalAuthorityStatus.Live, "https://www.fdean.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "2325", new LocalAuthorityDetails("Fylde Borough Council", LocalAuthorityStatus.NoFunding, "https://new.fylde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4505", new LocalAuthorityDetails("Gateshead Council", LocalAuthorityStatus.Live, "https://www.gateshead.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3020", new LocalAuthorityDetails("Gedling Borough Council", LocalAuthorityStatus.Live, "https://www.gedling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
-        { "9067", new LocalAuthorityDetails("Glasgow City Council", LocalAuthorityStatus.NoFunding, "https://www.glasgow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1620", new LocalAuthorityDetails("Gloucester City Council", LocalAuthorityStatus.Live, "https://www.gloucester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "1725", new LocalAuthorityDetails("Gosport Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "2230", new LocalAuthorityDetails("Gravesham Borough Council", LocalAuthorityStatus.Live, "https://www.gravesham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2615", new LocalAuthorityDetails("Great Yarmouth Borough Council", LocalAuthorityStatus.Live, "https://www.great-yarmouth.gov.uk/welcome", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3615", new LocalAuthorityDetails("Guildford Borough Council", LocalAuthorityStatus.Live, "https://www.guildford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "6810", new LocalAuthorityDetails("Gwynedd Council", LocalAuthorityStatus.NoFunding, "https://www.gwynedd.llyw.cymru/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "5360", new LocalAuthorityDetails("Hackney Council", LocalAuthorityStatus.Live, "https://hackney.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "650", new LocalAuthorityDetails("Halton Borough Council", LocalAuthorityStatus.Live, "https://www3.halton.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
-        { "2415", new LocalAuthorityDetails("Harborough District Council", LocalAuthorityStatus.Live, "https://www.harborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
-        { "5420", new LocalAuthorityDetails("Haringey Council", LocalAuthorityStatus.Live, "https://www.haringey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "1540", new LocalAuthorityDetails("Harlow Council", LocalAuthorityStatus.ReferralsPaused, "https://www.harlow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "1730", new LocalAuthorityDetails("Hart District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "724", new LocalAuthorityDetails("Hartlepool Borough Council", LocalAuthorityStatus.Live, "https://www.hartlepool.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1415", new LocalAuthorityDetails("Hastings Borough Council", LocalAuthorityStatus.Live, "https://www.hastings.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
-        { "1735", new LocalAuthorityDetails("Havant Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1850", new LocalAuthorityDetails("Herefordshire Council", LocalAuthorityStatus.Live, "https://www.herefordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Shropshire County Council") },
-        { "1920", new LocalAuthorityDetails("Hertsmere Borough Council", LocalAuthorityStatus.NoFunding, "https://www.hertsmere.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1030", new LocalAuthorityDetails("High Peak Borough Council", LocalAuthorityStatus.Live, "https://www.highpeak.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "5510", new LocalAuthorityDetails("Hillingdon Council", LocalAuthorityStatus.Live, "https://www.hillingdon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "2420", new LocalAuthorityDetails("Hinckley and Bosworth Borough Council", LocalAuthorityStatus.Live, "https://www.hinckley-bosworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
-        { "3825", new LocalAuthorityDetails("Horsham District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "2004", new LocalAuthorityDetails("Hull City Council", LocalAuthorityStatus.Live, "https://www.hull.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "520", new LocalAuthorityDetails("Huntingdonshire District Council", LocalAuthorityStatus.Live, "https://www.huntingdonshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
-        { "2330", new LocalAuthorityDetails("Hyndburn Borough", LocalAuthorityStatus.Live, "https://www.hyndburnbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "9069", new LocalAuthorityDetails("Inverclyde Council", LocalAuthorityStatus.NoFunding, "https://www.inverclyde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3515", new LocalAuthorityDetails("Ipswich Borough Council", LocalAuthorityStatus.Live, "https://www.ipswich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "6805", new LocalAuthorityDetails("Isle of Anglesey County Council", LocalAuthorityStatus.NoFunding, "https://www.anglesey.gov.uk/Cyngor-Sir-Ynys-Mon-Isle-of-Anglesey-County-Council.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2114", new LocalAuthorityDetails("Isle of Wight Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "835", new LocalAuthorityDetails("Isles of Scilly Council", LocalAuthorityStatus.Live, "https://www.scilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council") },
-        { "5570", new LocalAuthorityDetails("Islington Council", LocalAuthorityStatus.Live, "https://www.islington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "4715", new LocalAuthorityDetails("Kirklees Council", LocalAuthorityStatus.NoFunding, "https://www.kirklees.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4305", new LocalAuthorityDetails("Knowsley Council", LocalAuthorityStatus.Live, "https://www.knowsley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
-        { "5660", new LocalAuthorityDetails("Lambeth Council", LocalAuthorityStatus.Live, "https://www.lambeth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "2335", new LocalAuthorityDetails("Lancaster City Council", LocalAuthorityStatus.Live, "https://www.lancaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "4720", new LocalAuthorityDetails("Leeds City Council", LocalAuthorityStatus.Live, "https://www.leeds.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2465", new LocalAuthorityDetails("Leicester City Council", LocalAuthorityStatus.Live, "https://www.leicester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1425", new LocalAuthorityDetails("Lewes District Council", LocalAuthorityStatus.Live, "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
-        { "5690", new LocalAuthorityDetails("Lewisham Council", LocalAuthorityStatus.Live, "https://lewisham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "3415", new LocalAuthorityDetails("Lichfield City Council", LocalAuthorityStatus.Live, "https://www.lichfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "2515", new LocalAuthorityDetails("Lincoln City Council", LocalAuthorityStatus.Live, "https://www.lincoln.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
-        { "4310", new LocalAuthorityDetails("Liverpool City Council", LocalAuthorityStatus.Live, "https://liverpool.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
-        { "5060", new LocalAuthorityDetails("London Borough of Barking and Dagenham", LocalAuthorityStatus.Live, "https://www.lbbd.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "5120", new LocalAuthorityDetails("London Borough of Bexley", LocalAuthorityStatus.Live, "https://www.bexley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5180", new LocalAuthorityDetails("London Borough of Bromley", LocalAuthorityStatus.Live, "https://www.bromley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5210", new LocalAuthorityDetails("London Borough of Camden", LocalAuthorityStatus.Live, "https://www.camden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5390", new LocalAuthorityDetails("London Borough of Hammersmith and Fulham", LocalAuthorityStatus.Live, "https://www.lbhf.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5450", new LocalAuthorityDetails("London Borough of Harrow", LocalAuthorityStatus.Live, "https://www.harrow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5480", new LocalAuthorityDetails("London Borough of Havering", LocalAuthorityStatus.Live, "https://www.havering.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5540", new LocalAuthorityDetails("London Borough of Hounslow", LocalAuthorityStatus.Live, "https://www.hounslow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5720", new LocalAuthorityDetails("London Borough of Merton", LocalAuthorityStatus.Live, "https://www.merton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5780", new LocalAuthorityDetails("London Borough of Redbridge", LocalAuthorityStatus.Live, "https://www.redbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5810", new LocalAuthorityDetails("London Borough of Richmond upon Thames", LocalAuthorityStatus.Live, "https://www.richmond.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5870", new LocalAuthorityDetails("London Borough of Sutton", LocalAuthorityStatus.Live, "https://sutton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5930", new LocalAuthorityDetails("London Borough of Waltham Forest", LocalAuthorityStatus.Live, "https://www.walthamforest.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "230", new LocalAuthorityDetails("Luton Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "2235", new LocalAuthorityDetails("Maidstone Borough Council", LocalAuthorityStatus.NoFunding, "https://maidstone.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1545", new LocalAuthorityDetails("Maldon District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.maldon.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "1820", new LocalAuthorityDetails("Malvern Hills District Council", LocalAuthorityStatus.Live, "https://www.malvernhills.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire") },
-        { "4215", new LocalAuthorityDetails("Manchester City Council", LocalAuthorityStatus.NotParticipating, "https://www.manchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "3025", new LocalAuthorityDetails("Mansfield District Council", LocalAuthorityStatus.Live, "https://www.mansfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "2280", new LocalAuthorityDetails("Medway Council", LocalAuthorityStatus.NoLongerParticipating, "https://www.medway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2430", new LocalAuthorityDetails("Melton Borough Council", LocalAuthorityStatus.Live, "https://www.melton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
-        { "6925", new LocalAuthorityDetails("Merthyr Tydfil County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.merthyr.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1135", new LocalAuthorityDetails("Mid Devon District Council", LocalAuthorityStatus.Live, "https://www.middevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "3520", new LocalAuthorityDetails("Mid Suffolk District Council", LocalAuthorityStatus.Live, "https://www.midsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "3830", new LocalAuthorityDetails("Mid Sussex District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "734", new LocalAuthorityDetails("Middlesbrough Council", LocalAuthorityStatus.Live, "https://www.middlesbrough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
-        { "9070", new LocalAuthorityDetails("Midlothian Council", LocalAuthorityStatus.NoFunding, "https://www.midlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "435", new LocalAuthorityDetails("Milton Keynes Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "3620", new LocalAuthorityDetails("Mole Valley District Council", LocalAuthorityStatus.Live, "https://www.molevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "6840", new LocalAuthorityDetails("Monmouthshire County Council", LocalAuthorityStatus.NoFunding, "https://www.monmouthshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6930", new LocalAuthorityDetails("Neath Port Talbot County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.npt.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1740", new LocalAuthorityDetails("New Forest District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "3030", new LocalAuthorityDetails("Newark and Sherwood District Council", LocalAuthorityStatus.Live, "https://www.newark-sherwooddc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
-        { "4510", new LocalAuthorityDetails("Newcastle City Council", LocalAuthorityStatus.Live, "https://www.newcastle.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3420", new LocalAuthorityDetails("Newcastle-under-Lyme Borough Council", LocalAuthorityStatus.Live, "https://www.newcastle-staffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "5750", new LocalAuthorityDetails("Newham Council", LocalAuthorityStatus.Live, "https://www.newham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "6935", new LocalAuthorityDetails("Newport City Council", LocalAuthorityStatus.NoFunding, "https://www.newport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9072", new LocalAuthorityDetails("North Ayrshire Council", LocalAuthorityStatus.NoFunding, "https://www.north-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1115", new LocalAuthorityDetails("North Devon District Council", LocalAuthorityStatus.Live, "https://www.northdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "1035", new LocalAuthorityDetails("North East Derbyshire District Council", LocalAuthorityStatus.Live, "https://www.ne-derbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2002", new LocalAuthorityDetails("North East Lincolnshire Council", LocalAuthorityStatus.Live, "https://www.nelincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "1925", new LocalAuthorityDetails("North Hertfordshire District Council", LocalAuthorityStatus.Live, "https://www.north-herts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2520", new LocalAuthorityDetails("North Kesteven District Council", LocalAuthorityStatus.Live, "https://www.n-kesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
-        { "9073", new LocalAuthorityDetails("North Lanarkshire Council", LocalAuthorityStatus.NoFunding, "https://www.northlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2003", new LocalAuthorityDetails("North Lincolnshire Council", LocalAuthorityStatus.Live, "https://www.northlincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "2620", new LocalAuthorityDetails("North Norfolk District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
-        { "2840", new LocalAuthorityDetails("North Northamptonshire Council", LocalAuthorityStatus.Live, "https://www.northnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "121", new LocalAuthorityDetails("North Somerset Council", LocalAuthorityStatus.Live, "https://n-somerset.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council") },
-        { "4515", new LocalAuthorityDetails("North Tyneside Council", LocalAuthorityStatus.Live, "https://my.northtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3705", new LocalAuthorityDetails("North Warwickshire Borough Council", LocalAuthorityStatus.Live, "https://www.northwarks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "2435", new LocalAuthorityDetails("North West Leicestershire District Council", LocalAuthorityStatus.Live, "https://www.nwleics.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
-        { "2745", new LocalAuthorityDetails("North Yorkshire Council", LocalAuthorityStatus.Live, "https://www.northyorks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2935", new LocalAuthorityDetails("Northumberland County Council", LocalAuthorityStatus.Live, "https://www.northumberland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2625", new LocalAuthorityDetails("Norwich City Council", LocalAuthorityStatus.Live, "https://www.norwich.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3060", new LocalAuthorityDetails("Nottingham City Council", LocalAuthorityStatus.Live, "https://www.nottinghamcity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "3710", new LocalAuthorityDetails("Nuneaton and Bedworth Borough Council", LocalAuthorityStatus.Live, "https://www.nuneatonandbedworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "2440", new LocalAuthorityDetails("Oadby and Wigston Borough Council", LocalAuthorityStatus.Live, "https://www.oadby-wigston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "4220", new LocalAuthorityDetails("Oldham Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.oldham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "9000", new LocalAuthorityDetails("Orkney Islands Council", LocalAuthorityStatus.NoFunding, "https://www.orkney.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3110", new LocalAuthorityDetails("Oxford City Council", LocalAuthorityStatus.Live, "https://www.oxford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
-        { "3100", new LocalAuthorityDetails("Oxfordshire County Council", LocalAuthorityStatus.Live, "https://www.oxfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
-        { "6845", new LocalAuthorityDetails("Pembrokeshire County Council", LocalAuthorityStatus.NoFunding, "https://www.pembrokeshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2340", new LocalAuthorityDetails("Pendle Borough Council", LocalAuthorityStatus.Live, "https://www.pendle.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "9074", new LocalAuthorityDetails("Perth and Kinross Council", LocalAuthorityStatus.NoFunding, "https://www.pkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "540", new LocalAuthorityDetails("Peterborough City Council", LocalAuthorityStatus.Live, "https://www.peterborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
-        { "1160", new LocalAuthorityDetails("Plymouth City Council", LocalAuthorityStatus.Live, "https://www.plymouth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1775", new LocalAuthorityDetails("Portsmouth City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "6850", new LocalAuthorityDetails("Powys County Council", LocalAuthorityStatus.NoFunding, "https://www.powys.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2345", new LocalAuthorityDetails("Preston City Council", LocalAuthorityStatus.Live, "https://www.preston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "345", new LocalAuthorityDetails("Reading Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "728", new LocalAuthorityDetails("Redcar and Cleveland Borough", LocalAuthorityStatus.Live, "https://www.redcar-cleveland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
-        { "1825", new LocalAuthorityDetails("Redditch Borough Council", LocalAuthorityStatus.Live, "https://www.redditchbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "3625", new LocalAuthorityDetails("Reigate and Banstead Borough Council", LocalAuthorityStatus.Live, "https://www.reigate-banstead.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "9075", new LocalAuthorityDetails("Renfrewshire Council", LocalAuthorityStatus.NoFunding, "https://www.renfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "6940", new LocalAuthorityDetails("Rhondda Cynon Taf County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.rctcbc.gov.uk/Index.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2350", new LocalAuthorityDetails("Ribble Valley Borough Council", LocalAuthorityStatus.Live, "https://www.ribblevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "4225", new LocalAuthorityDetails("Rochdale Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.rochdale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "1550", new LocalAuthorityDetails("Rochford District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.rochford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "2355", new LocalAuthorityDetails("Rossendale Borough Council", LocalAuthorityStatus.Live, "https://www.rossendale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "1430", new LocalAuthorityDetails("Rother District Council", LocalAuthorityStatus.Live, "https://www.rother.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
-        { "4415", new LocalAuthorityDetails("Rotherham Metropolitan Borough Council", LocalAuthorityStatus.NoFunding, "https://www.rotherham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "5330", new LocalAuthorityDetails("Royal Borough of Greenwich", LocalAuthorityStatus.Live, "https://www.royalgreenwich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5600", new LocalAuthorityDetails("Royal Borough of Kensington and Chelsea", LocalAuthorityStatus.Live, "https://www.rbkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "5630", new LocalAuthorityDetails("Royal Borough of Kingston upon Thames", LocalAuthorityStatus.Live, "https://www.kingston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "355", new LocalAuthorityDetails("Royal Borough of Windsor and Maidenhead", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "3715", new LocalAuthorityDetails("Rugby Borough Council", LocalAuthorityStatus.Pending, "https://www.rugby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "3630", new LocalAuthorityDetails("Runnymede Borough Council", LocalAuthorityStatus.Live, "https://www.runnymede.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "3040", new LocalAuthorityDetails("Rushcliffe Borough Council", LocalAuthorityStatus.Live, "https://www.rushcliffe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
-        { "1750", new LocalAuthorityDetails("Rushmoor Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "2470", new LocalAuthorityDetails("Rutland County Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "4230", new LocalAuthorityDetails("Salford City Council", LocalAuthorityStatus.NotParticipating, "https://www.salford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "4620", new LocalAuthorityDetails("Sandwell Borough Council", LocalAuthorityStatus.Live, "https://www.sandwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "9055", new LocalAuthorityDetails("Scottish Borders Council", LocalAuthorityStatus.NoFunding, "https://www.scotborders.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4320", new LocalAuthorityDetails("Sefton Council", LocalAuthorityStatus.Live, "https://www.sefton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
-        { "2245", new LocalAuthorityDetails("Sevenoaks District Council", LocalAuthorityStatus.Live, "https://www.sevenoaks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4420", new LocalAuthorityDetails("Sheffield City Council", LocalAuthorityStatus.Live, "https://www.sheffield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9010", new LocalAuthorityDetails("Shetland Islands Council", LocalAuthorityStatus.NoFunding, "https://www.shetland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3245", new LocalAuthorityDetails("Shropshire County Council", LocalAuthorityStatus.Live, "https://www.shropshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Shropshire County Council") },
-        { "350", new LocalAuthorityDetails("Slough Borough Council", LocalAuthorityStatus.Live, "https://www.slough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4625", new LocalAuthorityDetails("Solihull Borough Council", LocalAuthorityStatus.Live, "https://www.solihull.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "3300", new LocalAuthorityDetails("Somerset Council", LocalAuthorityStatus.Live, "https://www.somerset.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9076", new LocalAuthorityDetails("South Ayrshire Council", LocalAuthorityStatus.NoFunding, "https://www.south-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "530", new LocalAuthorityDetails("South Cambridgeshire District Council", LocalAuthorityStatus.Live, "https://www.scambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
-        { "1040", new LocalAuthorityDetails("South Derbyshire District Council", LocalAuthorityStatus.Live, "https://www.southderbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "119", new LocalAuthorityDetails("South Gloucestershire Council", LocalAuthorityStatus.Live, "https://www.southglos.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "1125", new LocalAuthorityDetails("South Hams District Council", LocalAuthorityStatus.Live, "https://www.southhams.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Devon Borough Council") },
-        { "2525", new LocalAuthorityDetails("South Holland District Council", LocalAuthorityStatus.Live, "https://www.sholland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council") },
-        { "2530", new LocalAuthorityDetails("South Kesteven District Council", LocalAuthorityStatus.Live, "https://www.southkesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
-        { "9077", new LocalAuthorityDetails("South Lanarkshire Council", LocalAuthorityStatus.NoFunding, "https://www.southlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2630", new LocalAuthorityDetails("South Norfolk District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
-        { "3115", new LocalAuthorityDetails("South Oxfordshire District Council", LocalAuthorityStatus.Live, "https://www.southoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
-        { "2360", new LocalAuthorityDetails("South Ribble Borough Council", LocalAuthorityStatus.Live, "https://southribble.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "3430", new LocalAuthorityDetails("South Staffordshire District Council", LocalAuthorityStatus.Live, "https://www.sstaffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "4520", new LocalAuthorityDetails("South Tyneside Council", LocalAuthorityStatus.Live, "https://www.southtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1780", new LocalAuthorityDetails("Southampton City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1590", new LocalAuthorityDetails("Southend-on-Sea Borough Council", LocalAuthorityStatus.ReferralsPaused, "https://www.southend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "5840", new LocalAuthorityDetails("Southwark Council", LocalAuthorityStatus.Live, "https://www.southwark.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "3635", new LocalAuthorityDetails("Spelthorne Borough Council", LocalAuthorityStatus.Live, "https://www.spelthorne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "1930", new LocalAuthorityDetails("St Albans City Council", LocalAuthorityStatus.Live, "https://www.stalbans.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4315", new LocalAuthorityDetails("St. Helens Borough Council", LocalAuthorityStatus.Live, "https://www.sthelens.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
-        { "3425", new LocalAuthorityDetails("Stafford Borough Council", LocalAuthorityStatus.Live, "https://www.staffordbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "3435", new LocalAuthorityDetails("Staffordshire Moorlands District Council", LocalAuthorityStatus.Live, "https://www.staffsmoorlands.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "1935", new LocalAuthorityDetails("Stevenage Borough Council", LocalAuthorityStatus.Live, "https://www.stevenage.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9078", new LocalAuthorityDetails("Stirling Council", LocalAuthorityStatus.NoFunding, "https://www.stirling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4235", new LocalAuthorityDetails("Stockport Metropolitan Borough Council", LocalAuthorityStatus.NoFunding, "https://www.stockport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "738", new LocalAuthorityDetails("Stockton-on-Tees Borough Council", LocalAuthorityStatus.Live, "https://www.stockton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
-        { "3455", new LocalAuthorityDetails("Stoke-on-Trent City Council", LocalAuthorityStatus.Live, "https://www.stoke.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "3720", new LocalAuthorityDetails("Stratford-on-Avon District Council", LocalAuthorityStatus.Live, "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "1625", new LocalAuthorityDetails("Stroud District Council", LocalAuthorityStatus.Live, "https://www.stroud.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "3500", new LocalAuthorityDetails("Suffolk County Council", LocalAuthorityStatus.Live, "https://www.suffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "4525", new LocalAuthorityDetails("Sunderland City Council", LocalAuthorityStatus.Live, "https://www.sunderland.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3600", new LocalAuthorityDetails("Surrey County Council", LocalAuthorityStatus.Live, "https://www.surreycc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "3640", new LocalAuthorityDetails("Surrey Heath Borough Council", LocalAuthorityStatus.Live, "https://www.surreyheath.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "2255", new LocalAuthorityDetails("Swale Borough Council", LocalAuthorityStatus.NoFunding, "https://swale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3935", new LocalAuthorityDetails("Swindon Borough Council", LocalAuthorityStatus.NoFunding, "https://www.swindon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4240", new LocalAuthorityDetails("Tameside Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.tameside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "3445", new LocalAuthorityDetails("Tamworth Borough Council", LocalAuthorityStatus.Live, "https://www.tamworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
-        { "3645", new LocalAuthorityDetails("Tandridge District Council", LocalAuthorityStatus.Live, "https://www.tandridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "1130", new LocalAuthorityDetails("Teignbridge District Council", LocalAuthorityStatus.Live, "https://www.teignbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "3240", new LocalAuthorityDetails("Telford and Wrekin Council", LocalAuthorityStatus.Live, "https://www.telford.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Shropshire County Council") },
-        { "1560", new LocalAuthorityDetails("Tendring District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.tendringdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "1760", new LocalAuthorityDetails("Test Valley Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1630", new LocalAuthorityDetails("Tewkesbury Borough Council", LocalAuthorityStatus.Live, "https://tewkesbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
-        { "2260", new LocalAuthorityDetails("Thanet District Council", LocalAuthorityStatus.Live, "https://www.thanet.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9068", new LocalAuthorityDetails("The Highland Council", LocalAuthorityStatus.NoFunding, "https://www.highland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "9071", new LocalAuthorityDetails("The Moray Council", LocalAuthorityStatus.NoFunding, "http://www.moray.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1940", new LocalAuthorityDetails("Three Rivers District Council", LocalAuthorityStatus.Live, "https://www.threerivers.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council") },
-        { "1595", new LocalAuthorityDetails("Thurrock Council", LocalAuthorityStatus.ReferralsPaused, "https://www.thurrock.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "2265", new LocalAuthorityDetails("Tonbridge and Malling Borough Council", LocalAuthorityStatus.NoLongerParticipating, "https://www.tmbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1165", new LocalAuthorityDetails("Torbay Council", LocalAuthorityStatus.Live, "https://www.torbay.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "6945", new LocalAuthorityDetails("Torfaen County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.torfaen.gov.uk/intro-splash.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1145", new LocalAuthorityDetails("Torridge District Council", LocalAuthorityStatus.Live, "https://www.torridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
-        { "5900", new LocalAuthorityDetails("Tower Hamlets Council", LocalAuthorityStatus.Live, "https://www.towerhamlets.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "4245", new LocalAuthorityDetails("Trafford Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.trafford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "2270", new LocalAuthorityDetails("Tunbridge Wells Borough Council", LocalAuthorityStatus.Live, "https://tunbridgewells.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1570", new LocalAuthorityDetails("Uttlesford District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.uttlesford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
-        { "6950", new LocalAuthorityDetails("Vale of Glamorgan Council", LocalAuthorityStatus.NoFunding, "https://www.valeofglamorgan.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3120", new LocalAuthorityDetails("Vale of White Horse District Council", LocalAuthorityStatus.Live, "https://www.whitehorsedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
-        { "4725", new LocalAuthorityDetails("Wakefield Council", LocalAuthorityStatus.Live, "https://www.wakefield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "4630", new LocalAuthorityDetails("Walsall Metropolitan Borough Council", LocalAuthorityStatus.Live, "https://go.walsall.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "5960", new LocalAuthorityDetails("Wandsworth London Borough Council", LocalAuthorityStatus.Live, "https://www.wandsworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "655", new LocalAuthorityDetails("Warrington Borough Council", LocalAuthorityStatus.Live, "https://www.warrington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council") },
-        { "3725", new LocalAuthorityDetails("Warwick District Council", LocalAuthorityStatus.Live, "https://www.warwickdc.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
-        { "1945", new LocalAuthorityDetails("Watford Borough Council", LocalAuthorityStatus.Live, "https://www.watford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council") },
-        { "3650", new LocalAuthorityDetails("Waverley Borough Council", LocalAuthorityStatus.Live, "https://www.waverley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "1435", new LocalAuthorityDetails("Wealden District Council", LocalAuthorityStatus.Live, "https://www.wealden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1950", new LocalAuthorityDetails("Welwyn Hatfield Borough Council", LocalAuthorityStatus.Live, "https://www.welhat.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "340", new LocalAuthorityDetails("West Berkshire Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "1150", new LocalAuthorityDetails("West Devon Borough Council", LocalAuthorityStatus.Live, "https://www.westdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Devon Borough Council") },
-        { "9057", new LocalAuthorityDetails("West Dunbartonshire Council", LocalAuthorityStatus.NoFunding, "https://www.west-dunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2365", new LocalAuthorityDetails("West Lancashire District Council", LocalAuthorityStatus.Live, "https://www.westlancs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "2535", new LocalAuthorityDetails("West Lindsey District Council", LocalAuthorityStatus.Live, "https://www.west-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
-        { "9079", new LocalAuthorityDetails("West Lothian Council", LocalAuthorityStatus.NoFunding, "https://www.westlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "2845", new LocalAuthorityDetails("West Northamptonshire Council", LocalAuthorityStatus.Live, "https://www.westnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3125", new LocalAuthorityDetails("West Oxfordshire District Council", LocalAuthorityStatus.Live, "https://www.westoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
-        { "3545", new LocalAuthorityDetails("West Suffolk Council", LocalAuthorityStatus.Live, "https://www.westsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "5990", new LocalAuthorityDetails("Westminster City Council", LocalAuthorityStatus.Live, "https://www.westminster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
-        { "935", new LocalAuthorityDetails("Westmorland and Furness Council", LocalAuthorityStatus.Live, "https://www.westmorlandandfurness.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Westmorland and Furness Council") },
-        { "4250", new LocalAuthorityDetails("Wigan Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.wigan.gov.uk/index.aspx", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
-        { "3940", new LocalAuthorityDetails("Wiltshire Council", LocalAuthorityStatus.Live, "https://www.wiltshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1765", new LocalAuthorityDetails("Winchester City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "4325", new LocalAuthorityDetails("Wirral Council", LocalAuthorityStatus.Live, "https://www.wirral.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
-        { "3655", new LocalAuthorityDetails("Woking Borough Council", LocalAuthorityStatus.Live, "https://www.woking.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
-        { "360", new LocalAuthorityDetails("Wokingham Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "4635", new LocalAuthorityDetails("Wolverhampton City Council", LocalAuthorityStatus.Live, "https://www.wolverhampton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
-        { "1835", new LocalAuthorityDetails("Worcester City Council", LocalAuthorityStatus.Live, "https://www.worcester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire") },
-        { "1855", new LocalAuthorityDetails("Worcestershire County Council", LocalAuthorityStatus.NoFunding, "https://www.worcestershire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "3835", new LocalAuthorityDetails("Worthing Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
-        { "6955", new LocalAuthorityDetails("Wrexham County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.wrexham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
-        { "1840", new LocalAuthorityDetails("Wychavon District Council", LocalAuthorityStatus.Live, "https://www.wychavon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire") },
-        { "2370", new LocalAuthorityDetails("Wyre Borough Council", LocalAuthorityStatus.Live, "https://www.wyre.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
-        { "1845", new LocalAuthorityDetails("Wyre Forest District Council", LocalAuthorityStatus.Live, "https://www.wyreforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        {
+            "9051",
+            new LocalAuthorityDetails("Aberdeen City Council", LocalAuthorityStatus.NoFunding,
+                "https://www.aberdeencity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9052",
+            new LocalAuthorityDetails("Aberdeenshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.aberdeenshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3805",
+            new LocalAuthorityDetails("Adur District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1005",
+            new LocalAuthorityDetails("Amber Valley Borough Council", LocalAuthorityStatus.Live,
+                "https://www.ambervalley.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "9053",
+            new LocalAuthorityDetails("Angus Council", LocalAuthorityStatus.NoFunding, "https://www.angus.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9054",
+            new LocalAuthorityDetails("Argyll and Bute Council", LocalAuthorityStatus.NoFunding,
+                "https://www.argyll-bute.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3810",
+            new LocalAuthorityDetails("Arun District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "3005",
+            new LocalAuthorityDetails("Ashfield District Council", LocalAuthorityStatus.Live,
+                "https://www.ashfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottinghamshire County Council")
+        },
+        {
+            "2205",
+            new LocalAuthorityDetails("Ashford Borough Council", LocalAuthorityStatus.Live,
+                "https://www.ashford.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3505",
+            new LocalAuthorityDetails("Babergh District Council", LocalAuthorityStatus.Live,
+                "https://www.babergh.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
+        },
+        {
+            "5090",
+            new LocalAuthorityDetails("Barnet Council", LocalAuthorityStatus.Live, "https://www.barnet.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "4405",
+            new LocalAuthorityDetails("Barnsley Metropolitan Borough Council", LocalAuthorityStatus.Live,
+                "https://www.barnsley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1505",
+            new LocalAuthorityDetails("Basildon Council", LocalAuthorityStatus.Live, "https://www.basildon.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1705",
+            new LocalAuthorityDetails("Basingstoke and Deane Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "3010",
+            new LocalAuthorityDetails("Bassetlaw District Council", LocalAuthorityStatus.Live,
+                "https://www.bassetlaw.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "114",
+            new LocalAuthorityDetails("Bath and North East Somerset Council", LocalAuthorityStatus.Live,
+                "https://www.bathnes.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council")
+        },
+        {
+            "235",
+            new LocalAuthorityDetails("Bedford Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "4605",
+            new LocalAuthorityDetails("Birmingham City Council", LocalAuthorityStatus.Live,
+                "https://www.birmingham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "2405",
+            new LocalAuthorityDetails("Blaby District Council", LocalAuthorityStatus.Live, "https://www.blaby.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
+        },
+        {
+            "2372",
+            new LocalAuthorityDetails("Blackburn with Darwen Borough Council", LocalAuthorityStatus.Live,
+                "https://www.blackburn.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "2373",
+            new LocalAuthorityDetails("Blackpool Council", LocalAuthorityStatus.Live, "https://www.blackpool.gov.uk",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "6910",
+            new LocalAuthorityDetails("Blaenau Gwent County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.blaenau-gwent.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1010",
+            new LocalAuthorityDetails("Bolsover District Council", LocalAuthorityStatus.Live,
+                "https://www.bolsover.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "4205",
+            new LocalAuthorityDetails("Bolton Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.bolton.gov.uk", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "2635",
+            new LocalAuthorityDetails("Borough Council of King's Lynn & West Norfolk", LocalAuthorityStatus.Live,
+                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Broadland District Council")
+        },
+        {
+            "1905",
+            new LocalAuthorityDetails("Borough of Broxbourne Council", LocalAuthorityStatus.Live,
+                "https://www.broxbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2505",
+            new LocalAuthorityDetails("Boston Borough Council", LocalAuthorityStatus.Live, "https://www.boston.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council")
+        },
+        {
+            "1260",
+            new LocalAuthorityDetails("Bournemouth, Christchurch and Poole Council",
+                LocalAuthorityStatus.ReferralsPaused, "https://www.bcpcouncil.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Dorset Council")
+        },
+        {
+            "335",
+            new LocalAuthorityDetails("Bracknell Forest Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1510",
+            new LocalAuthorityDetails("Braintree District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.braintree.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "2605",
+            new LocalAuthorityDetails("Breckland District Council", LocalAuthorityStatus.Live,
+                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Broadland District Council")
+        },
+        {
+            "5150",
+            new LocalAuthorityDetails("Brent Council", LocalAuthorityStatus.Live, "https://www.brent.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "1515",
+            new LocalAuthorityDetails("Brentwood Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.brentwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "6915",
+            new LocalAuthorityDetails("Bridgend County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.bridgend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1445",
+            new LocalAuthorityDetails("Brighton and Hove City Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "116",
+            new LocalAuthorityDetails("Bristol City Council", LocalAuthorityStatus.Live, "https://www.bristol.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council")
+        },
+        {
+            "2610",
+            new LocalAuthorityDetails("Broadland District Council", LocalAuthorityStatus.Live,
+                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Broadland District Council")
+        },
+        {
+            "1805",
+            new LocalAuthorityDetails("Bromsgrove District Council", LocalAuthorityStatus.Live,
+                "https://www.bromsgrove.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "3015",
+            new LocalAuthorityDetails("Broxtowe Borough Council", LocalAuthorityStatus.Live,
+                "https://www.broxtowe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottinghamshire County Council")
+        },
+        {
+            "440",
+            new LocalAuthorityDetails("Buckinghamshire Council", LocalAuthorityStatus.Live,
+                "https://www.buckinghamshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2315",
+            new LocalAuthorityDetails("Burnley Borough Council", LocalAuthorityStatus.Live, "https://burnley.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "4210",
+            new LocalAuthorityDetails("Bury Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.bury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "6920",
+            new LocalAuthorityDetails("Caerphilly County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.caerphilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4710",
+            new LocalAuthorityDetails("Calderdale Council", LocalAuthorityStatus.Live, "https://new.calderdale.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "505",
+            new LocalAuthorityDetails("Cambridge City Council", LocalAuthorityStatus.Live,
+                "https://www.cambridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
+        },
+        {
+            "3405",
+            new LocalAuthorityDetails("Cannock Chase District Council", LocalAuthorityStatus.Live,
+                "https://www.cannockchasedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "2210",
+            new LocalAuthorityDetails("Canterbury City Council", LocalAuthorityStatus.Live,
+                "https://www.canterbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6825",
+            new LocalAuthorityDetails("Carmarthenshire County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.carmarthenshire.gov.wales/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1520",
+            new LocalAuthorityDetails("Castle Point District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.castlepoint.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "240",
+            new LocalAuthorityDetails("Central Bedfordshire Council", LocalAuthorityStatus.Pending,
+                "https://www.centralbedfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6820",
+            new LocalAuthorityDetails("Ceredigion County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.ceredigion.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2410",
+            new LocalAuthorityDetails("Charnwood Borough Council", LocalAuthorityStatus.Live,
+                "https://www.charnwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
+        },
+        {
+            "1525",
+            new LocalAuthorityDetails("Chelmsford City Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.chelmsford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "1605",
+            new LocalAuthorityDetails("Cheltenham Borough Council", LocalAuthorityStatus.Live,
+                "https://www.cheltenham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "3105",
+            new LocalAuthorityDetails("Cherwell District Council", LocalAuthorityStatus.Live,
+                "https://www.cherwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council")
+        },
+        {
+            "660",
+            new LocalAuthorityDetails("Cheshire East Council", LocalAuthorityStatus.Live,
+                "https://www.cheshireeast.gov.uk/home.aspx", IncomeBandOptions[IncomeThreshold._36000],
+                "Cheshire East Council")
+        },
+        {
+            "665",
+            new LocalAuthorityDetails("Cheshire West and Chester Council", LocalAuthorityStatus.Live,
+                "https://www.cheshirewestandchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Cheshire East Council")
+        },
+        {
+            "1015",
+            new LocalAuthorityDetails("Chesterfield Borough Council", LocalAuthorityStatus.Live,
+                "https://www.chesterfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "3815",
+            new LocalAuthorityDetails("Chichester District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "2320",
+            new LocalAuthorityDetails("Chorley Borough Council", LocalAuthorityStatus.Live, "https://chorley.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "6855",
+            new LocalAuthorityDetails("City and County of Swansea Council", LocalAuthorityStatus.NoFunding,
+                "https://www.swansea.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4705",
+            new LocalAuthorityDetails("City of Bradford Metropolitan District Council", LocalAuthorityStatus.Pending,
+                "https://www.bradford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6815",
+            new LocalAuthorityDetails("City of Cardiff Council", LocalAuthorityStatus.NoFunding,
+                "https://www.cardiff.gov.uk/ENG/Pages/default.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4410",
+            new LocalAuthorityDetails("City of Doncaster Council", LocalAuthorityStatus.Live,
+                "https://www.doncaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9064",
+            new LocalAuthorityDetails("City of Edinburgh Council", LocalAuthorityStatus.NoFunding,
+                "https://www.edinburgh.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "5030",
+            new LocalAuthorityDetails("City of London Corporation", LocalAuthorityStatus.Live,
+                "https://www.cityoflondon.gov.uk/about-us", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater London Authority")
+        },
+        {
+            "2741",
+            new LocalAuthorityDetails("City of York Council", LocalAuthorityStatus.Live, "https://www.york.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9056",
+            new LocalAuthorityDetails("Clackmannanshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.clacks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1530",
+            new LocalAuthorityDetails("Colchester City Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.colchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "9020",
+            new LocalAuthorityDetails("Comhairle nan Eilean Siar", LocalAuthorityStatus.NoFunding,
+                "https://www.cne-siar.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6905",
+            new LocalAuthorityDetails("Conwy County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.conwy.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "840",
+            new LocalAuthorityDetails("Cornwall Council", LocalAuthorityStatus.Live, "https://www.cornwall.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council")
+        },
+        {
+            "1610",
+            new LocalAuthorityDetails("Cotswold District Council", LocalAuthorityStatus.Live,
+                "https://www.cotswold.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "4610",
+            new LocalAuthorityDetails("Coventry City Council", LocalAuthorityStatus.Live,
+                "https://www.coventry.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "3820",
+            new LocalAuthorityDetails("Crawley Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "5240",
+            new LocalAuthorityDetails("Croydon Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "940",
+            new LocalAuthorityDetails("Cumberland Council", LocalAuthorityStatus.Live,
+                "https://www.cumberland.gov.uk/housing/warm-homes/warm-homes-local-grant",
+                IncomeBandOptions[IncomeThreshold._36000], "Westmorland and Furness Council")
+        },
+        {
+            "1910",
+            new LocalAuthorityDetails("Dacorum Borough Council", LocalAuthorityStatus.Live,
+                "https://www.dacorum.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1350",
+            new LocalAuthorityDetails("Darlington Borough Council", LocalAuthorityStatus.Live,
+                "https://www.darlington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Darlington Borough Council (Tees Consortium)")
+        },
+        {
+            "2215",
+            new LocalAuthorityDetails("Dartford Borough Council", LocalAuthorityStatus.Live,
+                "https://www.dartford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dover District Council")
+        },
+        {
+            "6830",
+            new LocalAuthorityDetails("Denbighshire County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.denbighshire.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1055",
+            new LocalAuthorityDetails("Derby City Council", LocalAuthorityStatus.Live, "https://www.derby.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "1045",
+            new LocalAuthorityDetails("Derbyshire Dales District Council", LocalAuthorityStatus.Live,
+                "https://www.derbyshiredales.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "1155",
+            new LocalAuthorityDetails("Devon County Council", LocalAuthorityStatus.Live, "https://www.devon.gov.uk",
+                IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "1265",
+            new LocalAuthorityDetails("Dorset Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.dorsetcouncil.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dorset Council")
+        },
+        {
+            "2220",
+            new LocalAuthorityDetails("Dover District Council", LocalAuthorityStatus.Live,
+                "https://www.dover.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000],
+                "Dover District Council")
+        },
+        {
+            "4615",
+            new LocalAuthorityDetails("Dudley Borough Council", LocalAuthorityStatus.Live,
+                "https://www.dudley.gov.uk/residents/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "9058",
+            new LocalAuthorityDetails("Dumfries and Galloway Council", LocalAuthorityStatus.NoFunding,
+                "https://www.dumfriesandgalloway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9059",
+            new LocalAuthorityDetails("Dundee City Council", LocalAuthorityStatus.NoFunding,
+                "https://www.dundeecity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1355",
+            new LocalAuthorityDetails("Durham County Council", LocalAuthorityStatus.Live, "https://www.durham.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "5270",
+            new LocalAuthorityDetails("Ealing Council", LocalAuthorityStatus.Live, "https://www.ealing.gov.uk/site/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "9060",
+            new LocalAuthorityDetails("East Ayrshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.east-ayrshire.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "510",
+            new LocalAuthorityDetails("East Cambridgeshire District Council", LocalAuthorityStatus.Live,
+                "https://eastcambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
+        },
+        {
+            "1105",
+            new LocalAuthorityDetails("East Devon District Council", LocalAuthorityStatus.Live,
+                "https://eastdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "9061",
+            new LocalAuthorityDetails("East Dunbartonshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.eastdunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1710",
+            new LocalAuthorityDetails("East Hampshire District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1915",
+            new LocalAuthorityDetails("East Hertfordshire District Council", LocalAuthorityStatus.Live,
+                "https://www.eastherts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2510",
+            new LocalAuthorityDetails("East Lindsey District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.e-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "East Lindsey District Council")
+        },
+        {
+            "9062",
+            new LocalAuthorityDetails("East Lothian Council", LocalAuthorityStatus.NoFunding,
+                "https://www.eastlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9063",
+            new LocalAuthorityDetails("East Renfrewshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.eastrenfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2001",
+            new LocalAuthorityDetails("East Riding of Yorkshire Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.eastriding.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3410",
+            new LocalAuthorityDetails("East Staffordshire Borough Council", LocalAuthorityStatus.Live,
+                "https://www.eaststaffsbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "3540",
+            new LocalAuthorityDetails("East Suffolk Council", LocalAuthorityStatus.Live,
+                "https://www.eastsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
+        },
+        {
+            "1440",
+            new LocalAuthorityDetails("East Sussex County Council", LocalAuthorityStatus.Live,
+                "https://www.eastsussex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council")
+        },
+        {
+            "1410",
+            new LocalAuthorityDetails("Eastbourne Borough Council", LocalAuthorityStatus.Live,
+                "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Lewes District Council")
+        },
+        {
+            "1715",
+            new LocalAuthorityDetails("Eastleigh Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "3605",
+            new LocalAuthorityDetails("Elmbridge Borough Council", LocalAuthorityStatus.Live,
+                "https://www.elmbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "5300",
+            new LocalAuthorityDetails("Enfield Council", LocalAuthorityStatus.Live, "https://www.enfield.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "1535",
+            new LocalAuthorityDetails("Epping Forest District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.eppingforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "3610",
+            new LocalAuthorityDetails("Epsom and Ewell Borough Council", LocalAuthorityStatus.Live,
+                "https://www.epsom-ewell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "1025",
+            new LocalAuthorityDetails("Erewash Borough Council", LocalAuthorityStatus.Live,
+                "https://www.erewash.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "1585",
+            new LocalAuthorityDetails("Essex County Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.essex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "1110",
+            new LocalAuthorityDetails("Exeter City Council", LocalAuthorityStatus.Live, "https://exeter.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "9065",
+            new LocalAuthorityDetails("Falkirk Council", LocalAuthorityStatus.NoFunding, "https://www.falkirk.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1720",
+            new LocalAuthorityDetails("Fareham Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "515",
+            new LocalAuthorityDetails("Fenland District Council", LocalAuthorityStatus.Live,
+                "https://www.fenland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
+        },
+        {
+            "9066",
+            new LocalAuthorityDetails("Fife Council", LocalAuthorityStatus.NoFunding, "https://www.fife.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6835",
+            new LocalAuthorityDetails("Flintshire County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.flintshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2250",
+            new LocalAuthorityDetails("Folkestone and Hythe District Council", LocalAuthorityStatus.NoFunding,
+                "https://www.folkestone-hythe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1615",
+            new LocalAuthorityDetails("Forest of Dean District Council", LocalAuthorityStatus.Live,
+                "https://www.fdean.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "2325",
+            new LocalAuthorityDetails("Fylde Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://new.fylde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4505",
+            new LocalAuthorityDetails("Gateshead Council", LocalAuthorityStatus.Live, "https://www.gateshead.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3020",
+            new LocalAuthorityDetails("Gedling Borough Council", LocalAuthorityStatus.Live,
+                "https://www.gedling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottinghamshire County Council")
+        },
+        {
+            "9067",
+            new LocalAuthorityDetails("Glasgow City Council", LocalAuthorityStatus.NoFunding,
+                "https://www.glasgow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1620",
+            new LocalAuthorityDetails("Gloucester City Council", LocalAuthorityStatus.Live,
+                "https://www.gloucester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "1725",
+            new LocalAuthorityDetails("Gosport Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "2230",
+            new LocalAuthorityDetails("Gravesham Borough Council", LocalAuthorityStatus.Live,
+                "https://www.gravesham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2615",
+            new LocalAuthorityDetails("Great Yarmouth Borough Council", LocalAuthorityStatus.Live,
+                "https://www.great-yarmouth.gov.uk/welcome", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3615",
+            new LocalAuthorityDetails("Guildford Borough Council", LocalAuthorityStatus.Live,
+                "https://www.guildford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "6810",
+            new LocalAuthorityDetails("Gwynedd Council", LocalAuthorityStatus.NoFunding,
+                "https://www.gwynedd.llyw.cymru/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "5360",
+            new LocalAuthorityDetails("Hackney Council", LocalAuthorityStatus.Live, "https://hackney.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "650",
+            new LocalAuthorityDetails("Halton Borough Council", LocalAuthorityStatus.Live, "https://www3.halton.gov.uk",
+                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
+        },
+        {
+            "2415",
+            new LocalAuthorityDetails("Harborough District Council", LocalAuthorityStatus.Live,
+                "https://www.harborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
+        },
+        {
+            "5420",
+            new LocalAuthorityDetails("Haringey Council", LocalAuthorityStatus.Live, "https://www.haringey.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "1540",
+            new LocalAuthorityDetails("Harlow Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.harlow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "1730",
+            new LocalAuthorityDetails("Hart District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "724",
+            new LocalAuthorityDetails("Hartlepool Borough Council", LocalAuthorityStatus.Live,
+                "https://www.hartlepool.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1415",
+            new LocalAuthorityDetails("Hastings Borough Council", LocalAuthorityStatus.Live,
+                "https://www.hastings.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council")
+        },
+        {
+            "1735",
+            new LocalAuthorityDetails("Havant Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1850",
+            new LocalAuthorityDetails("Herefordshire Council", LocalAuthorityStatus.Live,
+                "https://www.herefordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Shropshire County Council")
+        },
+        {
+            "1920",
+            new LocalAuthorityDetails("Hertsmere Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.hertsmere.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1030",
+            new LocalAuthorityDetails("High Peak Borough Council", LocalAuthorityStatus.Live,
+                "https://www.highpeak.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "5510",
+            new LocalAuthorityDetails("Hillingdon Council", LocalAuthorityStatus.Live, "https://www.hillingdon.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "2420",
+            new LocalAuthorityDetails("Hinckley and Bosworth Borough Council", LocalAuthorityStatus.Live,
+                "https://www.hinckley-bosworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
+        },
+        {
+            "3825",
+            new LocalAuthorityDetails("Horsham District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "2004",
+            new LocalAuthorityDetails("Hull City Council", LocalAuthorityStatus.Live, "https://www.hull.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "520",
+            new LocalAuthorityDetails("Huntingdonshire District Council", LocalAuthorityStatus.Live,
+                "https://www.huntingdonshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Cambridge City Council")
+        },
+        {
+            "2330",
+            new LocalAuthorityDetails("Hyndburn Borough", LocalAuthorityStatus.Live, "https://www.hyndburnbc.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "9069",
+            new LocalAuthorityDetails("Inverclyde Council", LocalAuthorityStatus.NoFunding,
+                "https://www.inverclyde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3515",
+            new LocalAuthorityDetails("Ipswich Borough Council", LocalAuthorityStatus.Live,
+                "https://www.ipswich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
+        },
+        {
+            "6805",
+            new LocalAuthorityDetails("Isle of Anglesey County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.anglesey.gov.uk/Cyngor-Sir-Ynys-Mon-Isle-of-Anglesey-County-Council.aspx",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2114",
+            new LocalAuthorityDetails("Isle of Wight Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "835",
+            new LocalAuthorityDetails("Isles of Scilly Council", LocalAuthorityStatus.Live,
+                "https://www.scilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council")
+        },
+        {
+            "5570",
+            new LocalAuthorityDetails("Islington Council", LocalAuthorityStatus.Live, "https://www.islington.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "4715",
+            new LocalAuthorityDetails("Kirklees Council", LocalAuthorityStatus.NoFunding,
+                "https://www.kirklees.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4305",
+            new LocalAuthorityDetails("Knowsley Council", LocalAuthorityStatus.Live, "https://www.knowsley.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
+        },
+        {
+            "5660",
+            new LocalAuthorityDetails("Lambeth Council", LocalAuthorityStatus.Live, "https://www.lambeth.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "2335",
+            new LocalAuthorityDetails("Lancaster City Council", LocalAuthorityStatus.Live,
+                "https://www.lancaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "4720",
+            new LocalAuthorityDetails("Leeds City Council", LocalAuthorityStatus.Live, "https://www.leeds.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2465",
+            new LocalAuthorityDetails("Leicester City Council", LocalAuthorityStatus.Live,
+                "https://www.leicester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1425",
+            new LocalAuthorityDetails("Lewes District Council", LocalAuthorityStatus.Live,
+                "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Lewes District Council")
+        },
+        {
+            "5690",
+            new LocalAuthorityDetails("Lewisham Council", LocalAuthorityStatus.Live, "https://lewisham.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "3415",
+            new LocalAuthorityDetails("Lichfield City Council", LocalAuthorityStatus.Live,
+                "https://www.lichfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "2515",
+            new LocalAuthorityDetails("Lincoln City Council", LocalAuthorityStatus.Live, "https://www.lincoln.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
+        },
+        {
+            "4310",
+            new LocalAuthorityDetails("Liverpool City Council", LocalAuthorityStatus.Live, "https://liverpool.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
+        },
+        {
+            "5060",
+            new LocalAuthorityDetails("London Borough of Barking and Dagenham", LocalAuthorityStatus.Live,
+                "https://www.lbbd.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "5120",
+            new LocalAuthorityDetails("London Borough of Bexley", LocalAuthorityStatus.Live,
+                "https://www.bexley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5180",
+            new LocalAuthorityDetails("London Borough of Bromley", LocalAuthorityStatus.Live,
+                "https://www.bromley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5210",
+            new LocalAuthorityDetails("London Borough of Camden", LocalAuthorityStatus.Live,
+                "https://www.camden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5390",
+            new LocalAuthorityDetails("London Borough of Hammersmith and Fulham", LocalAuthorityStatus.Live,
+                "https://www.lbhf.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5450",
+            new LocalAuthorityDetails("London Borough of Harrow", LocalAuthorityStatus.Live,
+                "https://www.harrow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5480",
+            new LocalAuthorityDetails("London Borough of Havering", LocalAuthorityStatus.Live,
+                "https://www.havering.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5540",
+            new LocalAuthorityDetails("London Borough of Hounslow", LocalAuthorityStatus.Live,
+                "https://www.hounslow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5720",
+            new LocalAuthorityDetails("London Borough of Merton", LocalAuthorityStatus.Live,
+                "https://www.merton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5780",
+            new LocalAuthorityDetails("London Borough of Redbridge", LocalAuthorityStatus.Live,
+                "https://www.redbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5810",
+            new LocalAuthorityDetails("London Borough of Richmond upon Thames", LocalAuthorityStatus.Live,
+                "https://www.richmond.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5870",
+            new LocalAuthorityDetails("London Borough of Sutton", LocalAuthorityStatus.Live, "https://sutton.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5930",
+            new LocalAuthorityDetails("London Borough of Waltham Forest", LocalAuthorityStatus.Live,
+                "https://www.walthamforest.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "230",
+            new LocalAuthorityDetails("Luton Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "2235",
+            new LocalAuthorityDetails("Maidstone Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://maidstone.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1545",
+            new LocalAuthorityDetails("Maldon District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.maldon.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "1820",
+            new LocalAuthorityDetails("Malvern Hills District Council", LocalAuthorityStatus.Live,
+                "https://www.malvernhills.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire")
+        },
+        {
+            "4215",
+            new LocalAuthorityDetails("Manchester City Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.manchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "3025",
+            new LocalAuthorityDetails("Mansfield District Council", LocalAuthorityStatus.Live,
+                "https://www.mansfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "2280",
+            new LocalAuthorityDetails("Medway Council", LocalAuthorityStatus.NoLongerParticipating,
+                "https://www.medway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2430",
+            new LocalAuthorityDetails("Melton Borough Council", LocalAuthorityStatus.Live, "https://www.melton.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
+        },
+        {
+            "6925",
+            new LocalAuthorityDetails("Merthyr Tydfil County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.merthyr.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1135",
+            new LocalAuthorityDetails("Mid Devon District Council", LocalAuthorityStatus.Live,
+                "https://www.middevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "3520",
+            new LocalAuthorityDetails("Mid Suffolk District Council", LocalAuthorityStatus.Live,
+                "https://www.midsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
+        },
+        {
+            "3830",
+            new LocalAuthorityDetails("Mid Sussex District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "734",
+            new LocalAuthorityDetails("Middlesbrough Council", LocalAuthorityStatus.Live,
+                "https://www.middlesbrough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Darlington Borough Council (Tees Consortium)")
+        },
+        {
+            "9070",
+            new LocalAuthorityDetails("Midlothian Council", LocalAuthorityStatus.NoFunding,
+                "https://www.midlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "435",
+            new LocalAuthorityDetails("Milton Keynes Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "3620",
+            new LocalAuthorityDetails("Mole Valley District Council", LocalAuthorityStatus.Live,
+                "https://www.molevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "6840",
+            new LocalAuthorityDetails("Monmouthshire County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.monmouthshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6930",
+            new LocalAuthorityDetails("Neath Port Talbot County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.npt.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1740",
+            new LocalAuthorityDetails("New Forest District Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "3030",
+            new LocalAuthorityDetails("Newark and Sherwood District Council", LocalAuthorityStatus.Live,
+                "https://www.newark-sherwooddc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottinghamshire County Council")
+        },
+        {
+            "4510",
+            new LocalAuthorityDetails("Newcastle City Council", LocalAuthorityStatus.Live,
+                "https://www.newcastle.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3420",
+            new LocalAuthorityDetails("Newcastle-under-Lyme Borough Council", LocalAuthorityStatus.Live,
+                "https://www.newcastle-staffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "5750",
+            new LocalAuthorityDetails("Newham Council", LocalAuthorityStatus.Live, "https://www.newham.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "6935",
+            new LocalAuthorityDetails("Newport City Council", LocalAuthorityStatus.NoFunding,
+                "https://www.newport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9072",
+            new LocalAuthorityDetails("North Ayrshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.north-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1115",
+            new LocalAuthorityDetails("North Devon District Council", LocalAuthorityStatus.Live,
+                "https://www.northdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "1035",
+            new LocalAuthorityDetails("North East Derbyshire District Council", LocalAuthorityStatus.Live,
+                "https://www.ne-derbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2002",
+            new LocalAuthorityDetails("North East Lincolnshire Council", LocalAuthorityStatus.Live,
+                "https://www.nelincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "1925",
+            new LocalAuthorityDetails("North Hertfordshire District Council", LocalAuthorityStatus.Live,
+                "https://www.north-herts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2520",
+            new LocalAuthorityDetails("North Kesteven District Council", LocalAuthorityStatus.Live,
+                "https://www.n-kesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
+        },
+        {
+            "9073",
+            new LocalAuthorityDetails("North Lanarkshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.northlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2003",
+            new LocalAuthorityDetails("North Lincolnshire Council", LocalAuthorityStatus.Live,
+                "https://www.northlincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "2620",
+            new LocalAuthorityDetails("North Norfolk District Council", LocalAuthorityStatus.Live,
+                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Broadland District Council")
+        },
+        {
+            "2840",
+            new LocalAuthorityDetails("North Northamptonshire Council", LocalAuthorityStatus.Live,
+                "https://www.northnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "121",
+            new LocalAuthorityDetails("North Somerset Council", LocalAuthorityStatus.Live, "https://n-somerset.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council")
+        },
+        {
+            "4515",
+            new LocalAuthorityDetails("North Tyneside Council", LocalAuthorityStatus.Live,
+                "https://my.northtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3705",
+            new LocalAuthorityDetails("North Warwickshire Borough Council", LocalAuthorityStatus.Live,
+                "https://www.northwarks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "2435",
+            new LocalAuthorityDetails("North West Leicestershire District Council", LocalAuthorityStatus.Live,
+                "https://www.nwleics.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
+        },
+        {
+            "2745",
+            new LocalAuthorityDetails("North Yorkshire Council", LocalAuthorityStatus.Live,
+                "https://www.northyorks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2935",
+            new LocalAuthorityDetails("Northumberland County Council", LocalAuthorityStatus.Live,
+                "https://www.northumberland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2625",
+            new LocalAuthorityDetails("Norwich City Council", LocalAuthorityStatus.Live,
+                "https://www.norwich.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3060",
+            new LocalAuthorityDetails("Nottingham City Council", LocalAuthorityStatus.Live,
+                "https://www.nottinghamcity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "3710",
+            new LocalAuthorityDetails("Nuneaton and Bedworth Borough Council", LocalAuthorityStatus.Live,
+                "https://www.nuneatonandbedworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "2440",
+            new LocalAuthorityDetails("Oadby and Wigston Borough Council", LocalAuthorityStatus.Live,
+                "https://www.oadby-wigston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "4220",
+            new LocalAuthorityDetails("Oldham Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.oldham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "9000",
+            new LocalAuthorityDetails("Orkney Islands Council", LocalAuthorityStatus.NoFunding,
+                "https://www.orkney.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3110",
+            new LocalAuthorityDetails("Oxford City Council", LocalAuthorityStatus.Live, "https://www.oxford.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council")
+        },
+        {
+            "3100",
+            new LocalAuthorityDetails("Oxfordshire County Council", LocalAuthorityStatus.Live,
+                "https://www.oxfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Oxfordshire County Council")
+        },
+        {
+            "6845",
+            new LocalAuthorityDetails("Pembrokeshire County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.pembrokeshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2340",
+            new LocalAuthorityDetails("Pendle Borough Council", LocalAuthorityStatus.Live, "https://www.pendle.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "9074",
+            new LocalAuthorityDetails("Perth and Kinross Council", LocalAuthorityStatus.NoFunding,
+                "https://www.pkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "540",
+            new LocalAuthorityDetails("Peterborough City Council", LocalAuthorityStatus.Live,
+                "https://www.peterborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
+        },
+        {
+            "1160",
+            new LocalAuthorityDetails("Plymouth City Council", LocalAuthorityStatus.Live,
+                "https://www.plymouth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1775",
+            new LocalAuthorityDetails("Portsmouth City Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "6850",
+            new LocalAuthorityDetails("Powys County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.powys.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2345",
+            new LocalAuthorityDetails("Preston City Council", LocalAuthorityStatus.Live, "https://www.preston.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "345",
+            new LocalAuthorityDetails("Reading Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "728",
+            new LocalAuthorityDetails("Redcar and Cleveland Borough", LocalAuthorityStatus.Live,
+                "https://www.redcar-cleveland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Darlington Borough Council (Tees Consortium)")
+        },
+        {
+            "1825",
+            new LocalAuthorityDetails("Redditch Borough Council", LocalAuthorityStatus.Live,
+                "https://www.redditchbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "3625",
+            new LocalAuthorityDetails("Reigate and Banstead Borough Council", LocalAuthorityStatus.Live,
+                "https://www.reigate-banstead.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Surrey County Council")
+        },
+        {
+            "9075",
+            new LocalAuthorityDetails("Renfrewshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.renfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "6940",
+            new LocalAuthorityDetails("Rhondda Cynon Taf County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.rctcbc.gov.uk/Index.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2350",
+            new LocalAuthorityDetails("Ribble Valley Borough Council", LocalAuthorityStatus.Live,
+                "https://www.ribblevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "4225",
+            new LocalAuthorityDetails("Rochdale Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.rochdale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "1550",
+            new LocalAuthorityDetails("Rochford District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.rochford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "2355",
+            new LocalAuthorityDetails("Rossendale Borough Council", LocalAuthorityStatus.Live,
+                "https://www.rossendale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "1430",
+            new LocalAuthorityDetails("Rother District Council", LocalAuthorityStatus.Live,
+                "https://www.rother.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council")
+        },
+        {
+            "4415",
+            new LocalAuthorityDetails("Rotherham Metropolitan Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.rotherham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "5330",
+            new LocalAuthorityDetails("Royal Borough of Greenwich", LocalAuthorityStatus.Live,
+                "https://www.royalgreenwich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater London Authority")
+        },
+        {
+            "5600",
+            new LocalAuthorityDetails("Royal Borough of Kensington and Chelsea", LocalAuthorityStatus.Live,
+                "https://www.rbkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "5630",
+            new LocalAuthorityDetails("Royal Borough of Kingston upon Thames", LocalAuthorityStatus.Live,
+                "https://www.kingston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "355",
+            new LocalAuthorityDetails("Royal Borough of Windsor and Maidenhead", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "3715",
+            new LocalAuthorityDetails("Rugby Borough Council", LocalAuthorityStatus.Pending,
+                "https://www.rugby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "3630",
+            new LocalAuthorityDetails("Runnymede Borough Council", LocalAuthorityStatus.Live,
+                "https://www.runnymede.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "3040",
+            new LocalAuthorityDetails("Rushcliffe Borough Council", LocalAuthorityStatus.Live,
+                "https://www.rushcliffe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottinghamshire County Council")
+        },
+        {
+            "1750",
+            new LocalAuthorityDetails("Rushmoor Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "2470",
+            new LocalAuthorityDetails("Rutland County Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "4230",
+            new LocalAuthorityDetails("Salford City Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.salford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "4620",
+            new LocalAuthorityDetails("Sandwell Borough Council", LocalAuthorityStatus.Live,
+                "https://www.sandwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "9055",
+            new LocalAuthorityDetails("Scottish Borders Council", LocalAuthorityStatus.NoFunding,
+                "https://www.scotborders.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4320",
+            new LocalAuthorityDetails("Sefton Council", LocalAuthorityStatus.Live, "https://www.sefton.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
+        },
+        {
+            "2245",
+            new LocalAuthorityDetails("Sevenoaks District Council", LocalAuthorityStatus.Live,
+                "https://www.sevenoaks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4420",
+            new LocalAuthorityDetails("Sheffield City Council", LocalAuthorityStatus.Live,
+                "https://www.sheffield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9010",
+            new LocalAuthorityDetails("Shetland Islands Council", LocalAuthorityStatus.NoFunding,
+                "https://www.shetland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3245",
+            new LocalAuthorityDetails("Shropshire County Council", LocalAuthorityStatus.Live,
+                "https://www.shropshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Shropshire County Council")
+        },
+        {
+            "350",
+            new LocalAuthorityDetails("Slough Borough Council", LocalAuthorityStatus.Live, "https://www.slough.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4625",
+            new LocalAuthorityDetails("Solihull Borough Council", LocalAuthorityStatus.Live,
+                "https://www.solihull.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "3300",
+            new LocalAuthorityDetails("Somerset Council", LocalAuthorityStatus.Live, "https://www.somerset.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9076",
+            new LocalAuthorityDetails("South Ayrshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.south-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "530",
+            new LocalAuthorityDetails("South Cambridgeshire District Council", LocalAuthorityStatus.Live,
+                "https://www.scambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
+        },
+        {
+            "1040",
+            new LocalAuthorityDetails("South Derbyshire District Council", LocalAuthorityStatus.Live,
+                "https://www.southderbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "119",
+            new LocalAuthorityDetails("South Gloucestershire Council", LocalAuthorityStatus.Live,
+                "https://www.southglos.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "1125",
+            new LocalAuthorityDetails("South Hams District Council", LocalAuthorityStatus.Live,
+                "https://www.southhams.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Devon Borough Council")
+        },
+        {
+            "2525",
+            new LocalAuthorityDetails("South Holland District Council", LocalAuthorityStatus.Live,
+                "https://www.sholland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "East Lindsey District Council")
+        },
+        {
+            "2530",
+            new LocalAuthorityDetails("South Kesteven District Council", LocalAuthorityStatus.Live,
+                "https://www.southkesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
+        },
+        {
+            "9077",
+            new LocalAuthorityDetails("South Lanarkshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.southlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2630",
+            new LocalAuthorityDetails("South Norfolk District Council", LocalAuthorityStatus.Live,
+                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Broadland District Council")
+        },
+        {
+            "3115",
+            new LocalAuthorityDetails("South Oxfordshire District Council", LocalAuthorityStatus.Live,
+                "https://www.southoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Oxfordshire County Council")
+        },
+        {
+            "2360",
+            new LocalAuthorityDetails("South Ribble Borough Council", LocalAuthorityStatus.Live,
+                "https://southribble.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "3430",
+            new LocalAuthorityDetails("South Staffordshire District Council", LocalAuthorityStatus.Live,
+                "https://www.sstaffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "4520",
+            new LocalAuthorityDetails("South Tyneside Council", LocalAuthorityStatus.Live,
+                "https://www.southtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1780",
+            new LocalAuthorityDetails("Southampton City Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1590",
+            new LocalAuthorityDetails("Southend-on-Sea Borough Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.southend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "5840",
+            new LocalAuthorityDetails("Southwark Council", LocalAuthorityStatus.Live, "https://www.southwark.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "3635",
+            new LocalAuthorityDetails("Spelthorne Borough Council", LocalAuthorityStatus.Live,
+                "https://www.spelthorne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "1930",
+            new LocalAuthorityDetails("St Albans City Council", LocalAuthorityStatus.Live,
+                "https://www.stalbans.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4315",
+            new LocalAuthorityDetails("St. Helens Borough Council", LocalAuthorityStatus.Live,
+                "https://www.sthelens.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Liverpool City Region Combined Authority")
+        },
+        {
+            "3425",
+            new LocalAuthorityDetails("Stafford Borough Council", LocalAuthorityStatus.Live,
+                "https://www.staffordbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "3435",
+            new LocalAuthorityDetails("Staffordshire Moorlands District Council", LocalAuthorityStatus.Live,
+                "https://www.staffsmoorlands.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "1935",
+            new LocalAuthorityDetails("Stevenage Borough Council", LocalAuthorityStatus.Live,
+                "https://www.stevenage.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9078",
+            new LocalAuthorityDetails("Stirling Council", LocalAuthorityStatus.NoFunding,
+                "https://www.stirling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4235",
+            new LocalAuthorityDetails("Stockport Metropolitan Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.stockport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "738",
+            new LocalAuthorityDetails("Stockton-on-Tees Borough Council", LocalAuthorityStatus.Live,
+                "https://www.stockton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Darlington Borough Council (Tees Consortium)")
+        },
+        {
+            "3455",
+            new LocalAuthorityDetails("Stoke-on-Trent City Council", LocalAuthorityStatus.Live,
+                "https://www.stoke.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "3720",
+            new LocalAuthorityDetails("Stratford-on-Avon District Council", LocalAuthorityStatus.Live,
+                "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
+        },
+        {
+            "1625",
+            new LocalAuthorityDetails("Stroud District Council", LocalAuthorityStatus.Live,
+                "https://www.stroud.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "3500",
+            new LocalAuthorityDetails("Suffolk County Council", LocalAuthorityStatus.Live,
+                "https://www.suffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
+        },
+        {
+            "4525",
+            new LocalAuthorityDetails("Sunderland City Council", LocalAuthorityStatus.Live,
+                "https://www.sunderland.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3600",
+            new LocalAuthorityDetails("Surrey County Council", LocalAuthorityStatus.Live,
+                "https://www.surreycc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "3640",
+            new LocalAuthorityDetails("Surrey Heath Borough Council", LocalAuthorityStatus.Live,
+                "https://www.surreyheath.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "2255",
+            new LocalAuthorityDetails("Swale Borough Council", LocalAuthorityStatus.NoFunding, "https://swale.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3935",
+            new LocalAuthorityDetails("Swindon Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.swindon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4240",
+            new LocalAuthorityDetails("Tameside Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.tameside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "3445",
+            new LocalAuthorityDetails("Tamworth Borough Council", LocalAuthorityStatus.Live,
+                "https://www.tamworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
+        },
+        {
+            "3645",
+            new LocalAuthorityDetails("Tandridge District Council", LocalAuthorityStatus.Live,
+                "https://www.tandridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "1130",
+            new LocalAuthorityDetails("Teignbridge District Council", LocalAuthorityStatus.Live,
+                "https://www.teignbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "3240",
+            new LocalAuthorityDetails("Telford and Wrekin Council", LocalAuthorityStatus.Live,
+                "https://www.telford.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000],
+                "Shropshire County Council")
+        },
+        {
+            "1560",
+            new LocalAuthorityDetails("Tendring District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.tendringdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "1760",
+            new LocalAuthorityDetails("Test Valley Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1630",
+            new LocalAuthorityDetails("Tewkesbury Borough Council", LocalAuthorityStatus.Live,
+                "https://tewkesbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
+        },
+        {
+            "2260",
+            new LocalAuthorityDetails("Thanet District Council", LocalAuthorityStatus.Live,
+                "https://www.thanet.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9068",
+            new LocalAuthorityDetails("The Highland Council", LocalAuthorityStatus.NoFunding,
+                "https://www.highland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "9071",
+            new LocalAuthorityDetails("The Moray Council", LocalAuthorityStatus.NoFunding, "http://www.moray.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1940",
+            new LocalAuthorityDetails("Three Rivers District Council", LocalAuthorityStatus.Live,
+                "https://www.threerivers.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council")
+        },
+        {
+            "1595",
+            new LocalAuthorityDetails("Thurrock Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.thurrock.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "2265",
+            new LocalAuthorityDetails("Tonbridge and Malling Borough Council",
+                LocalAuthorityStatus.NoLongerParticipating, "https://www.tmbc.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1165",
+            new LocalAuthorityDetails("Torbay Council", LocalAuthorityStatus.Live, "https://www.torbay.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "6945",
+            new LocalAuthorityDetails("Torfaen County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.torfaen.gov.uk/intro-splash.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1145",
+            new LocalAuthorityDetails("Torridge District Council", LocalAuthorityStatus.Live,
+                "https://www.torridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
+        },
+        {
+            "5900",
+            new LocalAuthorityDetails("Tower Hamlets Council", LocalAuthorityStatus.Live,
+                "https://www.towerhamlets.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater London Authority")
+        },
+        {
+            "4245",
+            new LocalAuthorityDetails("Trafford Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.trafford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "2270",
+            new LocalAuthorityDetails("Tunbridge Wells Borough Council", LocalAuthorityStatus.Live,
+                "https://tunbridgewells.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1570",
+            new LocalAuthorityDetails("Uttlesford District Council", LocalAuthorityStatus.ReferralsPaused,
+                "https://www.uttlesford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
+        },
+        {
+            "6950",
+            new LocalAuthorityDetails("Vale of Glamorgan Council", LocalAuthorityStatus.NoFunding,
+                "https://www.valeofglamorgan.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3120",
+            new LocalAuthorityDetails("Vale of White Horse District Council", LocalAuthorityStatus.Live,
+                "https://www.whitehorsedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Oxfordshire County Council")
+        },
+        {
+            "4725",
+            new LocalAuthorityDetails("Wakefield Council", LocalAuthorityStatus.Live, "https://www.wakefield.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "4630",
+            new LocalAuthorityDetails("Walsall Metropolitan Borough Council", LocalAuthorityStatus.Live,
+                "https://go.walsall.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "5960",
+            new LocalAuthorityDetails("Wandsworth London Borough Council", LocalAuthorityStatus.Live,
+                "https://www.wandsworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
+        },
+        {
+            "655",
+            new LocalAuthorityDetails("Warrington Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warrington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council")
+        },
+        {
+            "3725",
+            new LocalAuthorityDetails("Warwick District Council", LocalAuthorityStatus.Live,
+                "https://www.warwickdc.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000],
+                "Nottingham City Council")
+        },
+        {
+            "1945",
+            new LocalAuthorityDetails("Watford Borough Council", LocalAuthorityStatus.Live,
+                "https://www.watford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council")
+        },
+        {
+            "3650",
+            new LocalAuthorityDetails("Waverley Borough Council", LocalAuthorityStatus.Live,
+                "https://www.waverley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "1435",
+            new LocalAuthorityDetails("Wealden District Council", LocalAuthorityStatus.Live,
+                "https://www.wealden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1950",
+            new LocalAuthorityDetails("Welwyn Hatfield Borough Council", LocalAuthorityStatus.Live,
+                "https://www.welhat.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "340",
+            new LocalAuthorityDetails("West Berkshire Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "1150",
+            new LocalAuthorityDetails("West Devon Borough Council", LocalAuthorityStatus.Live,
+                "https://www.westdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Devon Borough Council")
+        },
+        {
+            "9057",
+            new LocalAuthorityDetails("West Dunbartonshire Council", LocalAuthorityStatus.NoFunding,
+                "https://www.west-dunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2365",
+            new LocalAuthorityDetails("West Lancashire District Council", LocalAuthorityStatus.Live,
+                "https://www.westlancs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "2535",
+            new LocalAuthorityDetails("West Lindsey District Council", LocalAuthorityStatus.Live,
+                "https://www.west-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
+        },
+        {
+            "9079",
+            new LocalAuthorityDetails("West Lothian Council", LocalAuthorityStatus.NoFunding,
+                "https://www.westlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "2845",
+            new LocalAuthorityDetails("West Northamptonshire Council", LocalAuthorityStatus.Live,
+                "https://www.westnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3125",
+            new LocalAuthorityDetails("West Oxfordshire District Council", LocalAuthorityStatus.Live,
+                "https://www.westoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council")
+        },
+        {
+            "3545",
+            new LocalAuthorityDetails("West Suffolk Council", LocalAuthorityStatus.Live,
+                "https://www.westsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
+        },
+        {
+            "5990",
+            new LocalAuthorityDetails("Westminster City Council", LocalAuthorityStatus.Live,
+                "https://www.westminster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater London Authority")
+        },
+        {
+            "935",
+            new LocalAuthorityDetails("Westmorland and Furness Council", LocalAuthorityStatus.Live,
+                "https://www.westmorlandandfurness.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "Westmorland and Furness Council")
+        },
+        {
+            "4250",
+            new LocalAuthorityDetails("Wigan Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
+                "https://www.wigan.gov.uk/index.aspx", IncomeBandOptions[IncomeThreshold._36000],
+                "Greater Manchester Combined Authority")
+        },
+        {
+            "3940",
+            new LocalAuthorityDetails("Wiltshire Council", LocalAuthorityStatus.Live, "https://www.wiltshire.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1765",
+            new LocalAuthorityDetails("Winchester City Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "4325",
+            new LocalAuthorityDetails("Wirral Council", LocalAuthorityStatus.Live, "https://www.wirral.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
+        },
+        {
+            "3655",
+            new LocalAuthorityDetails("Woking Borough Council", LocalAuthorityStatus.Live, "https://www.woking.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
+        },
+        {
+            "360",
+            new LocalAuthorityDetails("Wokingham Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "4635",
+            new LocalAuthorityDetails("Wolverhampton City Council", LocalAuthorityStatus.Live,
+                "https://www.wolverhampton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
+                "West Midlands Combined Authority")
+        },
+        {
+            "1835",
+            new LocalAuthorityDetails("Worcester City Council", LocalAuthorityStatus.Live,
+                "https://www.worcester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire")
+        },
+        {
+            "1855",
+            new LocalAuthorityDetails("Worcestershire County Council", LocalAuthorityStatus.NoFunding,
+                "https://www.worcestershire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "3835",
+            new LocalAuthorityDetails("Worthing Borough Council", LocalAuthorityStatus.Live,
+                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
+        },
+        {
+            "6955",
+            new LocalAuthorityDetails("Wrexham County Borough Council", LocalAuthorityStatus.NoFunding,
+                "https://www.wrexham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        },
+        {
+            "1840",
+            new LocalAuthorityDetails("Wychavon District Council", LocalAuthorityStatus.Live,
+                "https://www.wychavon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire")
+        },
+        {
+            "2370",
+            new LocalAuthorityDetails("Wyre Borough Council", LocalAuthorityStatus.Live, "https://www.wyre.gov.uk/",
+                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
+        },
+        {
+            "1845",
+            new LocalAuthorityDetails("Wyre Forest District Council", LocalAuthorityStatus.Live,
+                "https://www.wyreforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
+        }
     };
 
     public static readonly IEnumerable<string> LiveWmcaCustodianCodes = FilterCustodianCodes(
         ConsortiumNames.WestMidlandsCombinedAuthority,
         LocalAuthorityStatus.Live);
+
+    public static readonly IReadOnlyList<string> ManagedByLcrcaCodes = new[] { "650", "4305", "4315", "4325" };
+
+    public static IEnumerable<string> FilterCustodianCodes(
+        string consortium,
+        LocalAuthorityStatus? status = null)
+    {
+        return LocalAuthorityDetailsByCustodianCode
+            .Where(localAuthority =>
+                localAuthority.Value.Consortium == consortium &&
+                (status == null || localAuthority.Value.Status == status))
+            .Select(localAuthority => localAuthority.Key)
+            .ToList();
+    }
 
     public static bool CustodianCodeIsInConsortium(string custodianCode, string consortium)
     {
@@ -427,17 +1909,27 @@ public class LocalAuthorityData
                localAuthority.Consortium == consortium;
     }
 
-    public static readonly IReadOnlyList<string> ManagedByLcrcaCodes = new[] { "650", "4305", "4315", "4325" };
-    
     public static bool CustodianCodeIsManagedByLcrca(string custodianCode)
     {
-        return 
-            CustodianCodeIsInConsortium(custodianCode, ConsortiumNames.LiverpoolCityRegionCombinedAuthority) 
+        return
+            CustodianCodeIsInConsortium(custodianCode, ConsortiumNames.LiverpoolCityRegionCombinedAuthority)
             // not all LAs in the LCRCA are managed by the LCRCA, so we must filter further to
             // Halton
             // Knowsley
             // St Helens
             // Wirral
             && ManagedByLcrcaCodes.Contains(custodianCode);
+    }
+
+    public record LocalAuthorityDetails(
+        string Name,
+        LocalAuthorityStatus Status,
+        string WebsiteUrl,
+        IncomeBand[] IncomeBandOptions,
+        string? Consortium);
+
+    private enum IncomeThreshold
+    {
+        _36000
     }
 }

--- a/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -15,10 +15,34 @@ public class LocalAuthorityData
         Live
     }
 
+    public record LocalAuthorityDetails(
+        string Name,
+        LocalAuthorityStatus Status,
+        string WebsiteUrl,
+        IncomeBand[] IncomeBandOptions,
+        string? Consortium);
+
+    private enum IncomeThreshold
+    {
+        _36000
+    }
+
     private static readonly Dictionary<IncomeThreshold, IncomeBand[]> IncomeBandOptions = new()
     {
         { IncomeThreshold._36000, new[] { IncomeBand.UnderOrEqualTo36000, IncomeBand.GreaterThan36000 } }
     };
+
+    public static IEnumerable<string> FilterCustodianCodes(
+        string consortium,
+        LocalAuthorityStatus? status = null)
+    {
+        return LocalAuthorityDetailsByCustodianCode
+            .Where(localAuthority =>
+                localAuthority.Value.Consortium == consortium &&
+                (status == null || localAuthority.Value.Status == status))
+            .Select(localAuthority => localAuthority.Key)
+            .ToList();
+    }
 
     // The list of custodian codes comes from the publicly available "Local custodian codes" download link
     // on https://docs.os.uk/os-downloads/addressing-and-location/addressbase-core-principles/addressbase-local-custodian-codes
@@ -34,1874 +58,368 @@ public class LocalAuthorityData
     // Avoid making manual changes to this code if possible
     public static readonly Dictionary<string, LocalAuthorityDetails> LocalAuthorityDetailsByCustodianCode = new()
     {
-        {
-            "9051",
-            new LocalAuthorityDetails("Aberdeen City Council", LocalAuthorityStatus.NoFunding,
-                "https://www.aberdeencity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9052",
-            new LocalAuthorityDetails("Aberdeenshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.aberdeenshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3805",
-            new LocalAuthorityDetails("Adur District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1005",
-            new LocalAuthorityDetails("Amber Valley Borough Council", LocalAuthorityStatus.Live,
-                "https://www.ambervalley.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "9053",
-            new LocalAuthorityDetails("Angus Council", LocalAuthorityStatus.NoFunding, "https://www.angus.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9054",
-            new LocalAuthorityDetails("Argyll and Bute Council", LocalAuthorityStatus.NoFunding,
-                "https://www.argyll-bute.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3810",
-            new LocalAuthorityDetails("Arun District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "3005",
-            new LocalAuthorityDetails("Ashfield District Council", LocalAuthorityStatus.Live,
-                "https://www.ashfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottinghamshire County Council")
-        },
-        {
-            "2205",
-            new LocalAuthorityDetails("Ashford Borough Council", LocalAuthorityStatus.Live,
-                "https://www.ashford.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3505",
-            new LocalAuthorityDetails("Babergh District Council", LocalAuthorityStatus.Live,
-                "https://www.babergh.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
-        },
-        {
-            "5090",
-            new LocalAuthorityDetails("Barnet Council", LocalAuthorityStatus.Live, "https://www.barnet.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "4405",
-            new LocalAuthorityDetails("Barnsley Metropolitan Borough Council", LocalAuthorityStatus.Live,
-                "https://www.barnsley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1505",
-            new LocalAuthorityDetails("Basildon Council", LocalAuthorityStatus.Live, "https://www.basildon.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1705",
-            new LocalAuthorityDetails("Basingstoke and Deane Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "3010",
-            new LocalAuthorityDetails("Bassetlaw District Council", LocalAuthorityStatus.Live,
-                "https://www.bassetlaw.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "114",
-            new LocalAuthorityDetails("Bath and North East Somerset Council", LocalAuthorityStatus.Live,
-                "https://www.bathnes.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council")
-        },
-        {
-            "235",
-            new LocalAuthorityDetails("Bedford Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "4605",
-            new LocalAuthorityDetails("Birmingham City Council", LocalAuthorityStatus.Live,
-                "https://www.birmingham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "2405",
-            new LocalAuthorityDetails("Blaby District Council", LocalAuthorityStatus.Live, "https://www.blaby.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
-        },
-        {
-            "2372",
-            new LocalAuthorityDetails("Blackburn with Darwen Borough Council", LocalAuthorityStatus.Live,
-                "https://www.blackburn.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "2373",
-            new LocalAuthorityDetails("Blackpool Council", LocalAuthorityStatus.Live, "https://www.blackpool.gov.uk",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "6910",
-            new LocalAuthorityDetails("Blaenau Gwent County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.blaenau-gwent.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1010",
-            new LocalAuthorityDetails("Bolsover District Council", LocalAuthorityStatus.Live,
-                "https://www.bolsover.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "4205",
-            new LocalAuthorityDetails("Bolton Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.bolton.gov.uk", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "2635",
-            new LocalAuthorityDetails("Borough Council of King's Lynn & West Norfolk", LocalAuthorityStatus.Live,
-                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Broadland District Council")
-        },
-        {
-            "1905",
-            new LocalAuthorityDetails("Borough of Broxbourne Council", LocalAuthorityStatus.Live,
-                "https://www.broxbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2505",
-            new LocalAuthorityDetails("Boston Borough Council", LocalAuthorityStatus.Live, "https://www.boston.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council")
-        },
-        {
-            "1260",
-            new LocalAuthorityDetails("Bournemouth, Christchurch and Poole Council",
-                LocalAuthorityStatus.ReferralsPaused, "https://www.bcpcouncil.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Dorset Council")
-        },
-        {
-            "335",
-            new LocalAuthorityDetails("Bracknell Forest Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1510",
-            new LocalAuthorityDetails("Braintree District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.braintree.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "2605",
-            new LocalAuthorityDetails("Breckland District Council", LocalAuthorityStatus.Live,
-                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Broadland District Council")
-        },
-        {
-            "5150",
-            new LocalAuthorityDetails("Brent Council", LocalAuthorityStatus.Live, "https://www.brent.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "1515",
-            new LocalAuthorityDetails("Brentwood Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.brentwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "6915",
-            new LocalAuthorityDetails("Bridgend County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.bridgend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1445",
-            new LocalAuthorityDetails("Brighton and Hove City Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "116",
-            new LocalAuthorityDetails("Bristol City Council", LocalAuthorityStatus.Live, "https://www.bristol.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council")
-        },
-        {
-            "2610",
-            new LocalAuthorityDetails("Broadland District Council", LocalAuthorityStatus.Live,
-                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Broadland District Council")
-        },
-        {
-            "1805",
-            new LocalAuthorityDetails("Bromsgrove District Council", LocalAuthorityStatus.Live,
-                "https://www.bromsgrove.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "3015",
-            new LocalAuthorityDetails("Broxtowe Borough Council", LocalAuthorityStatus.Live,
-                "https://www.broxtowe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottinghamshire County Council")
-        },
-        {
-            "440",
-            new LocalAuthorityDetails("Buckinghamshire Council", LocalAuthorityStatus.Live,
-                "https://www.buckinghamshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2315",
-            new LocalAuthorityDetails("Burnley Borough Council", LocalAuthorityStatus.Live, "https://burnley.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "4210",
-            new LocalAuthorityDetails("Bury Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.bury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "6920",
-            new LocalAuthorityDetails("Caerphilly County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.caerphilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4710",
-            new LocalAuthorityDetails("Calderdale Council", LocalAuthorityStatus.Live, "https://new.calderdale.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "505",
-            new LocalAuthorityDetails("Cambridge City Council", LocalAuthorityStatus.Live,
-                "https://www.cambridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
-        },
-        {
-            "3405",
-            new LocalAuthorityDetails("Cannock Chase District Council", LocalAuthorityStatus.Live,
-                "https://www.cannockchasedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "2210",
-            new LocalAuthorityDetails("Canterbury City Council", LocalAuthorityStatus.Live,
-                "https://www.canterbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6825",
-            new LocalAuthorityDetails("Carmarthenshire County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.carmarthenshire.gov.wales/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1520",
-            new LocalAuthorityDetails("Castle Point District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.castlepoint.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "240",
-            new LocalAuthorityDetails("Central Bedfordshire Council", LocalAuthorityStatus.Pending,
-                "https://www.centralbedfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6820",
-            new LocalAuthorityDetails("Ceredigion County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.ceredigion.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2410",
-            new LocalAuthorityDetails("Charnwood Borough Council", LocalAuthorityStatus.Live,
-                "https://www.charnwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
-        },
-        {
-            "1525",
-            new LocalAuthorityDetails("Chelmsford City Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.chelmsford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "1605",
-            new LocalAuthorityDetails("Cheltenham Borough Council", LocalAuthorityStatus.Live,
-                "https://www.cheltenham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "3105",
-            new LocalAuthorityDetails("Cherwell District Council", LocalAuthorityStatus.Live,
-                "https://www.cherwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council")
-        },
-        {
-            "660",
-            new LocalAuthorityDetails("Cheshire East Council", LocalAuthorityStatus.Live,
-                "https://www.cheshireeast.gov.uk/home.aspx", IncomeBandOptions[IncomeThreshold._36000],
-                "Cheshire East Council")
-        },
-        {
-            "665",
-            new LocalAuthorityDetails("Cheshire West and Chester Council", LocalAuthorityStatus.Live,
-                "https://www.cheshirewestandchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Cheshire East Council")
-        },
-        {
-            "1015",
-            new LocalAuthorityDetails("Chesterfield Borough Council", LocalAuthorityStatus.Live,
-                "https://www.chesterfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "3815",
-            new LocalAuthorityDetails("Chichester District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "2320",
-            new LocalAuthorityDetails("Chorley Borough Council", LocalAuthorityStatus.Live, "https://chorley.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "6855",
-            new LocalAuthorityDetails("City and County of Swansea Council", LocalAuthorityStatus.NoFunding,
-                "https://www.swansea.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4705",
-            new LocalAuthorityDetails("City of Bradford Metropolitan District Council", LocalAuthorityStatus.Pending,
-                "https://www.bradford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6815",
-            new LocalAuthorityDetails("City of Cardiff Council", LocalAuthorityStatus.NoFunding,
-                "https://www.cardiff.gov.uk/ENG/Pages/default.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4410",
-            new LocalAuthorityDetails("City of Doncaster Council", LocalAuthorityStatus.Live,
-                "https://www.doncaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9064",
-            new LocalAuthorityDetails("City of Edinburgh Council", LocalAuthorityStatus.NoFunding,
-                "https://www.edinburgh.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "5030",
-            new LocalAuthorityDetails("City of London Corporation", LocalAuthorityStatus.Live,
-                "https://www.cityoflondon.gov.uk/about-us", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater London Authority")
-        },
-        {
-            "2741",
-            new LocalAuthorityDetails("City of York Council", LocalAuthorityStatus.Live, "https://www.york.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9056",
-            new LocalAuthorityDetails("Clackmannanshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.clacks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1530",
-            new LocalAuthorityDetails("Colchester City Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.colchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "9020",
-            new LocalAuthorityDetails("Comhairle nan Eilean Siar", LocalAuthorityStatus.NoFunding,
-                "https://www.cne-siar.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6905",
-            new LocalAuthorityDetails("Conwy County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.conwy.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "840",
-            new LocalAuthorityDetails("Cornwall Council", LocalAuthorityStatus.Live, "https://www.cornwall.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council")
-        },
-        {
-            "1610",
-            new LocalAuthorityDetails("Cotswold District Council", LocalAuthorityStatus.Live,
-                "https://www.cotswold.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "4610",
-            new LocalAuthorityDetails("Coventry City Council", LocalAuthorityStatus.Live,
-                "https://www.coventry.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "3820",
-            new LocalAuthorityDetails("Crawley Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "5240",
-            new LocalAuthorityDetails("Croydon Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "940",
-            new LocalAuthorityDetails("Cumberland Council", LocalAuthorityStatus.Live,
-                "https://www.cumberland.gov.uk/housing/warm-homes/warm-homes-local-grant",
-                IncomeBandOptions[IncomeThreshold._36000], "Westmorland and Furness Council")
-        },
-        {
-            "1910",
-            new LocalAuthorityDetails("Dacorum Borough Council", LocalAuthorityStatus.Live,
-                "https://www.dacorum.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1350",
-            new LocalAuthorityDetails("Darlington Borough Council", LocalAuthorityStatus.Live,
-                "https://www.darlington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Darlington Borough Council (Tees Consortium)")
-        },
-        {
-            "2215",
-            new LocalAuthorityDetails("Dartford Borough Council", LocalAuthorityStatus.Live,
-                "https://www.dartford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dover District Council")
-        },
-        {
-            "6830",
-            new LocalAuthorityDetails("Denbighshire County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.denbighshire.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1055",
-            new LocalAuthorityDetails("Derby City Council", LocalAuthorityStatus.Live, "https://www.derby.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "1045",
-            new LocalAuthorityDetails("Derbyshire Dales District Council", LocalAuthorityStatus.Live,
-                "https://www.derbyshiredales.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "1155",
-            new LocalAuthorityDetails("Devon County Council", LocalAuthorityStatus.Live, "https://www.devon.gov.uk",
-                IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "1265",
-            new LocalAuthorityDetails("Dorset Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.dorsetcouncil.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dorset Council")
-        },
-        {
-            "2220",
-            new LocalAuthorityDetails("Dover District Council", LocalAuthorityStatus.Live,
-                "https://www.dover.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000],
-                "Dover District Council")
-        },
-        {
-            "4615",
-            new LocalAuthorityDetails("Dudley Borough Council", LocalAuthorityStatus.Live,
-                "https://www.dudley.gov.uk/residents/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "9058",
-            new LocalAuthorityDetails("Dumfries and Galloway Council", LocalAuthorityStatus.NoFunding,
-                "https://www.dumfriesandgalloway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9059",
-            new LocalAuthorityDetails("Dundee City Council", LocalAuthorityStatus.NoFunding,
-                "https://www.dundeecity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1355",
-            new LocalAuthorityDetails("Durham County Council", LocalAuthorityStatus.Live, "https://www.durham.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "5270",
-            new LocalAuthorityDetails("Ealing Council", LocalAuthorityStatus.Live, "https://www.ealing.gov.uk/site/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "9060",
-            new LocalAuthorityDetails("East Ayrshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.east-ayrshire.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "510",
-            new LocalAuthorityDetails("East Cambridgeshire District Council", LocalAuthorityStatus.Live,
-                "https://eastcambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
-        },
-        {
-            "1105",
-            new LocalAuthorityDetails("East Devon District Council", LocalAuthorityStatus.Live,
-                "https://eastdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "9061",
-            new LocalAuthorityDetails("East Dunbartonshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.eastdunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1710",
-            new LocalAuthorityDetails("East Hampshire District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1915",
-            new LocalAuthorityDetails("East Hertfordshire District Council", LocalAuthorityStatus.Live,
-                "https://www.eastherts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2510",
-            new LocalAuthorityDetails("East Lindsey District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.e-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "East Lindsey District Council")
-        },
-        {
-            "9062",
-            new LocalAuthorityDetails("East Lothian Council", LocalAuthorityStatus.NoFunding,
-                "https://www.eastlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9063",
-            new LocalAuthorityDetails("East Renfrewshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.eastrenfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2001",
-            new LocalAuthorityDetails("East Riding of Yorkshire Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.eastriding.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3410",
-            new LocalAuthorityDetails("East Staffordshire Borough Council", LocalAuthorityStatus.Live,
-                "https://www.eaststaffsbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "3540",
-            new LocalAuthorityDetails("East Suffolk Council", LocalAuthorityStatus.Live,
-                "https://www.eastsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
-        },
-        {
-            "1440",
-            new LocalAuthorityDetails("East Sussex County Council", LocalAuthorityStatus.Live,
-                "https://www.eastsussex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council")
-        },
-        {
-            "1410",
-            new LocalAuthorityDetails("Eastbourne Borough Council", LocalAuthorityStatus.Live,
-                "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Lewes District Council")
-        },
-        {
-            "1715",
-            new LocalAuthorityDetails("Eastleigh Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "3605",
-            new LocalAuthorityDetails("Elmbridge Borough Council", LocalAuthorityStatus.Live,
-                "https://www.elmbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "5300",
-            new LocalAuthorityDetails("Enfield Council", LocalAuthorityStatus.Live, "https://www.enfield.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "1535",
-            new LocalAuthorityDetails("Epping Forest District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.eppingforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "3610",
-            new LocalAuthorityDetails("Epsom and Ewell Borough Council", LocalAuthorityStatus.Live,
-                "https://www.epsom-ewell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "1025",
-            new LocalAuthorityDetails("Erewash Borough Council", LocalAuthorityStatus.Live,
-                "https://www.erewash.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "1585",
-            new LocalAuthorityDetails("Essex County Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.essex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "1110",
-            new LocalAuthorityDetails("Exeter City Council", LocalAuthorityStatus.Live, "https://exeter.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "9065",
-            new LocalAuthorityDetails("Falkirk Council", LocalAuthorityStatus.NoFunding, "https://www.falkirk.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1720",
-            new LocalAuthorityDetails("Fareham Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "515",
-            new LocalAuthorityDetails("Fenland District Council", LocalAuthorityStatus.Live,
-                "https://www.fenland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
-        },
-        {
-            "9066",
-            new LocalAuthorityDetails("Fife Council", LocalAuthorityStatus.NoFunding, "https://www.fife.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6835",
-            new LocalAuthorityDetails("Flintshire County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.flintshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2250",
-            new LocalAuthorityDetails("Folkestone and Hythe District Council", LocalAuthorityStatus.NoFunding,
-                "https://www.folkestone-hythe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1615",
-            new LocalAuthorityDetails("Forest of Dean District Council", LocalAuthorityStatus.Live,
-                "https://www.fdean.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "2325",
-            new LocalAuthorityDetails("Fylde Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://new.fylde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4505",
-            new LocalAuthorityDetails("Gateshead Council", LocalAuthorityStatus.Live, "https://www.gateshead.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3020",
-            new LocalAuthorityDetails("Gedling Borough Council", LocalAuthorityStatus.Live,
-                "https://www.gedling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottinghamshire County Council")
-        },
-        {
-            "9067",
-            new LocalAuthorityDetails("Glasgow City Council", LocalAuthorityStatus.NoFunding,
-                "https://www.glasgow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1620",
-            new LocalAuthorityDetails("Gloucester City Council", LocalAuthorityStatus.Live,
-                "https://www.gloucester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "1725",
-            new LocalAuthorityDetails("Gosport Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "2230",
-            new LocalAuthorityDetails("Gravesham Borough Council", LocalAuthorityStatus.Live,
-                "https://www.gravesham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2615",
-            new LocalAuthorityDetails("Great Yarmouth Borough Council", LocalAuthorityStatus.Live,
-                "https://www.great-yarmouth.gov.uk/welcome", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3615",
-            new LocalAuthorityDetails("Guildford Borough Council", LocalAuthorityStatus.Live,
-                "https://www.guildford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "6810",
-            new LocalAuthorityDetails("Gwynedd Council", LocalAuthorityStatus.NoFunding,
-                "https://www.gwynedd.llyw.cymru/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "5360",
-            new LocalAuthorityDetails("Hackney Council", LocalAuthorityStatus.Live, "https://hackney.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "650",
-            new LocalAuthorityDetails("Halton Borough Council", LocalAuthorityStatus.Live, "https://www3.halton.gov.uk",
-                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
-        },
-        {
-            "2415",
-            new LocalAuthorityDetails("Harborough District Council", LocalAuthorityStatus.Live,
-                "https://www.harborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
-        },
-        {
-            "5420",
-            new LocalAuthorityDetails("Haringey Council", LocalAuthorityStatus.Live, "https://www.haringey.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "1540",
-            new LocalAuthorityDetails("Harlow Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.harlow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "1730",
-            new LocalAuthorityDetails("Hart District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "724",
-            new LocalAuthorityDetails("Hartlepool Borough Council", LocalAuthorityStatus.Live,
-                "https://www.hartlepool.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1415",
-            new LocalAuthorityDetails("Hastings Borough Council", LocalAuthorityStatus.Live,
-                "https://www.hastings.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council")
-        },
-        {
-            "1735",
-            new LocalAuthorityDetails("Havant Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1850",
-            new LocalAuthorityDetails("Herefordshire Council", LocalAuthorityStatus.Live,
-                "https://www.herefordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Shropshire County Council")
-        },
-        {
-            "1920",
-            new LocalAuthorityDetails("Hertsmere Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.hertsmere.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1030",
-            new LocalAuthorityDetails("High Peak Borough Council", LocalAuthorityStatus.Live,
-                "https://www.highpeak.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "5510",
-            new LocalAuthorityDetails("Hillingdon Council", LocalAuthorityStatus.Live, "https://www.hillingdon.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "2420",
-            new LocalAuthorityDetails("Hinckley and Bosworth Borough Council", LocalAuthorityStatus.Live,
-                "https://www.hinckley-bosworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
-        },
-        {
-            "3825",
-            new LocalAuthorityDetails("Horsham District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "2004",
-            new LocalAuthorityDetails("Hull City Council", LocalAuthorityStatus.Live, "https://www.hull.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "520",
-            new LocalAuthorityDetails("Huntingdonshire District Council", LocalAuthorityStatus.Live,
-                "https://www.huntingdonshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Cambridge City Council")
-        },
-        {
-            "2330",
-            new LocalAuthorityDetails("Hyndburn Borough", LocalAuthorityStatus.Live, "https://www.hyndburnbc.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "9069",
-            new LocalAuthorityDetails("Inverclyde Council", LocalAuthorityStatus.NoFunding,
-                "https://www.inverclyde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3515",
-            new LocalAuthorityDetails("Ipswich Borough Council", LocalAuthorityStatus.Live,
-                "https://www.ipswich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
-        },
-        {
-            "6805",
-            new LocalAuthorityDetails("Isle of Anglesey County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.anglesey.gov.uk/Cyngor-Sir-Ynys-Mon-Isle-of-Anglesey-County-Council.aspx",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2114",
-            new LocalAuthorityDetails("Isle of Wight Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "835",
-            new LocalAuthorityDetails("Isles of Scilly Council", LocalAuthorityStatus.Live,
-                "https://www.scilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council")
-        },
-        {
-            "5570",
-            new LocalAuthorityDetails("Islington Council", LocalAuthorityStatus.Live, "https://www.islington.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "4715",
-            new LocalAuthorityDetails("Kirklees Council", LocalAuthorityStatus.NoFunding,
-                "https://www.kirklees.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4305",
-            new LocalAuthorityDetails("Knowsley Council", LocalAuthorityStatus.Live, "https://www.knowsley.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
-        },
-        {
-            "5660",
-            new LocalAuthorityDetails("Lambeth Council", LocalAuthorityStatus.Live, "https://www.lambeth.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "2335",
-            new LocalAuthorityDetails("Lancaster City Council", LocalAuthorityStatus.Live,
-                "https://www.lancaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "4720",
-            new LocalAuthorityDetails("Leeds City Council", LocalAuthorityStatus.Live, "https://www.leeds.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2465",
-            new LocalAuthorityDetails("Leicester City Council", LocalAuthorityStatus.Live,
-                "https://www.leicester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1425",
-            new LocalAuthorityDetails("Lewes District Council", LocalAuthorityStatus.Live,
-                "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Lewes District Council")
-        },
-        {
-            "5690",
-            new LocalAuthorityDetails("Lewisham Council", LocalAuthorityStatus.Live, "https://lewisham.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "3415",
-            new LocalAuthorityDetails("Lichfield City Council", LocalAuthorityStatus.Live,
-                "https://www.lichfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "2515",
-            new LocalAuthorityDetails("Lincoln City Council", LocalAuthorityStatus.Live, "https://www.lincoln.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
-        },
-        {
-            "4310",
-            new LocalAuthorityDetails("Liverpool City Council", LocalAuthorityStatus.Live, "https://liverpool.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
-        },
-        {
-            "5060",
-            new LocalAuthorityDetails("London Borough of Barking and Dagenham", LocalAuthorityStatus.Live,
-                "https://www.lbbd.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "5120",
-            new LocalAuthorityDetails("London Borough of Bexley", LocalAuthorityStatus.Live,
-                "https://www.bexley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5180",
-            new LocalAuthorityDetails("London Borough of Bromley", LocalAuthorityStatus.Live,
-                "https://www.bromley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5210",
-            new LocalAuthorityDetails("London Borough of Camden", LocalAuthorityStatus.Live,
-                "https://www.camden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5390",
-            new LocalAuthorityDetails("London Borough of Hammersmith and Fulham", LocalAuthorityStatus.Live,
-                "https://www.lbhf.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5450",
-            new LocalAuthorityDetails("London Borough of Harrow", LocalAuthorityStatus.Live,
-                "https://www.harrow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5480",
-            new LocalAuthorityDetails("London Borough of Havering", LocalAuthorityStatus.Live,
-                "https://www.havering.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5540",
-            new LocalAuthorityDetails("London Borough of Hounslow", LocalAuthorityStatus.Live,
-                "https://www.hounslow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5720",
-            new LocalAuthorityDetails("London Borough of Merton", LocalAuthorityStatus.Live,
-                "https://www.merton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5780",
-            new LocalAuthorityDetails("London Borough of Redbridge", LocalAuthorityStatus.Live,
-                "https://www.redbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5810",
-            new LocalAuthorityDetails("London Borough of Richmond upon Thames", LocalAuthorityStatus.Live,
-                "https://www.richmond.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5870",
-            new LocalAuthorityDetails("London Borough of Sutton", LocalAuthorityStatus.Live, "https://sutton.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5930",
-            new LocalAuthorityDetails("London Borough of Waltham Forest", LocalAuthorityStatus.Live,
-                "https://www.walthamforest.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "230",
-            new LocalAuthorityDetails("Luton Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "2235",
-            new LocalAuthorityDetails("Maidstone Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://maidstone.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1545",
-            new LocalAuthorityDetails("Maldon District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.maldon.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "1820",
-            new LocalAuthorityDetails("Malvern Hills District Council", LocalAuthorityStatus.Live,
-                "https://www.malvernhills.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire")
-        },
-        {
-            "4215",
-            new LocalAuthorityDetails("Manchester City Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.manchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "3025",
-            new LocalAuthorityDetails("Mansfield District Council", LocalAuthorityStatus.Live,
-                "https://www.mansfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "2280",
-            new LocalAuthorityDetails("Medway Council", LocalAuthorityStatus.NoLongerParticipating,
-                "https://www.medway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2430",
-            new LocalAuthorityDetails("Melton Borough Council", LocalAuthorityStatus.Live, "https://www.melton.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
-        },
-        {
-            "6925",
-            new LocalAuthorityDetails("Merthyr Tydfil County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.merthyr.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1135",
-            new LocalAuthorityDetails("Mid Devon District Council", LocalAuthorityStatus.Live,
-                "https://www.middevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "3520",
-            new LocalAuthorityDetails("Mid Suffolk District Council", LocalAuthorityStatus.Live,
-                "https://www.midsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
-        },
-        {
-            "3830",
-            new LocalAuthorityDetails("Mid Sussex District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "734",
-            new LocalAuthorityDetails("Middlesbrough Council", LocalAuthorityStatus.Live,
-                "https://www.middlesbrough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Darlington Borough Council (Tees Consortium)")
-        },
-        {
-            "9070",
-            new LocalAuthorityDetails("Midlothian Council", LocalAuthorityStatus.NoFunding,
-                "https://www.midlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "435",
-            new LocalAuthorityDetails("Milton Keynes Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "3620",
-            new LocalAuthorityDetails("Mole Valley District Council", LocalAuthorityStatus.Live,
-                "https://www.molevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "6840",
-            new LocalAuthorityDetails("Monmouthshire County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.monmouthshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6930",
-            new LocalAuthorityDetails("Neath Port Talbot County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.npt.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1740",
-            new LocalAuthorityDetails("New Forest District Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "3030",
-            new LocalAuthorityDetails("Newark and Sherwood District Council", LocalAuthorityStatus.Live,
-                "https://www.newark-sherwooddc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottinghamshire County Council")
-        },
-        {
-            "4510",
-            new LocalAuthorityDetails("Newcastle City Council", LocalAuthorityStatus.Live,
-                "https://www.newcastle.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3420",
-            new LocalAuthorityDetails("Newcastle-under-Lyme Borough Council", LocalAuthorityStatus.Live,
-                "https://www.newcastle-staffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "5750",
-            new LocalAuthorityDetails("Newham Council", LocalAuthorityStatus.Live, "https://www.newham.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "6935",
-            new LocalAuthorityDetails("Newport City Council", LocalAuthorityStatus.NoFunding,
-                "https://www.newport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9072",
-            new LocalAuthorityDetails("North Ayrshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.north-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1115",
-            new LocalAuthorityDetails("North Devon District Council", LocalAuthorityStatus.Live,
-                "https://www.northdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "1035",
-            new LocalAuthorityDetails("North East Derbyshire District Council", LocalAuthorityStatus.Live,
-                "https://www.ne-derbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2002",
-            new LocalAuthorityDetails("North East Lincolnshire Council", LocalAuthorityStatus.Live,
-                "https://www.nelincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "1925",
-            new LocalAuthorityDetails("North Hertfordshire District Council", LocalAuthorityStatus.Live,
-                "https://www.north-herts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2520",
-            new LocalAuthorityDetails("North Kesteven District Council", LocalAuthorityStatus.Live,
-                "https://www.n-kesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
-        },
-        {
-            "9073",
-            new LocalAuthorityDetails("North Lanarkshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.northlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2003",
-            new LocalAuthorityDetails("North Lincolnshire Council", LocalAuthorityStatus.Live,
-                "https://www.northlincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "2620",
-            new LocalAuthorityDetails("North Norfolk District Council", LocalAuthorityStatus.Live,
-                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Broadland District Council")
-        },
-        {
-            "2840",
-            new LocalAuthorityDetails("North Northamptonshire Council", LocalAuthorityStatus.Live,
-                "https://www.northnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "121",
-            new LocalAuthorityDetails("North Somerset Council", LocalAuthorityStatus.Live, "https://n-somerset.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council")
-        },
-        {
-            "4515",
-            new LocalAuthorityDetails("North Tyneside Council", LocalAuthorityStatus.Live,
-                "https://my.northtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3705",
-            new LocalAuthorityDetails("North Warwickshire Borough Council", LocalAuthorityStatus.Live,
-                "https://www.northwarks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "2435",
-            new LocalAuthorityDetails("North West Leicestershire District Council", LocalAuthorityStatus.Live,
-                "https://www.nwleics.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire")
-        },
-        {
-            "2745",
-            new LocalAuthorityDetails("North Yorkshire Council", LocalAuthorityStatus.Live,
-                "https://www.northyorks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2935",
-            new LocalAuthorityDetails("Northumberland County Council", LocalAuthorityStatus.Live,
-                "https://www.northumberland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2625",
-            new LocalAuthorityDetails("Norwich City Council", LocalAuthorityStatus.Live,
-                "https://www.norwich.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3060",
-            new LocalAuthorityDetails("Nottingham City Council", LocalAuthorityStatus.Live,
-                "https://www.nottinghamcity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "3710",
-            new LocalAuthorityDetails("Nuneaton and Bedworth Borough Council", LocalAuthorityStatus.Live,
-                "https://www.nuneatonandbedworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "2440",
-            new LocalAuthorityDetails("Oadby and Wigston Borough Council", LocalAuthorityStatus.Live,
-                "https://www.oadby-wigston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "4220",
-            new LocalAuthorityDetails("Oldham Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.oldham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "9000",
-            new LocalAuthorityDetails("Orkney Islands Council", LocalAuthorityStatus.NoFunding,
-                "https://www.orkney.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3110",
-            new LocalAuthorityDetails("Oxford City Council", LocalAuthorityStatus.Live, "https://www.oxford.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council")
-        },
-        {
-            "3100",
-            new LocalAuthorityDetails("Oxfordshire County Council", LocalAuthorityStatus.Live,
-                "https://www.oxfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Oxfordshire County Council")
-        },
-        {
-            "6845",
-            new LocalAuthorityDetails("Pembrokeshire County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.pembrokeshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2340",
-            new LocalAuthorityDetails("Pendle Borough Council", LocalAuthorityStatus.Live, "https://www.pendle.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "9074",
-            new LocalAuthorityDetails("Perth and Kinross Council", LocalAuthorityStatus.NoFunding,
-                "https://www.pkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "540",
-            new LocalAuthorityDetails("Peterborough City Council", LocalAuthorityStatus.Live,
-                "https://www.peterborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
-        },
-        {
-            "1160",
-            new LocalAuthorityDetails("Plymouth City Council", LocalAuthorityStatus.Live,
-                "https://www.plymouth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1775",
-            new LocalAuthorityDetails("Portsmouth City Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "6850",
-            new LocalAuthorityDetails("Powys County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.powys.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2345",
-            new LocalAuthorityDetails("Preston City Council", LocalAuthorityStatus.Live, "https://www.preston.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "345",
-            new LocalAuthorityDetails("Reading Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "728",
-            new LocalAuthorityDetails("Redcar and Cleveland Borough", LocalAuthorityStatus.Live,
-                "https://www.redcar-cleveland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Darlington Borough Council (Tees Consortium)")
-        },
-        {
-            "1825",
-            new LocalAuthorityDetails("Redditch Borough Council", LocalAuthorityStatus.Live,
-                "https://www.redditchbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "3625",
-            new LocalAuthorityDetails("Reigate and Banstead Borough Council", LocalAuthorityStatus.Live,
-                "https://www.reigate-banstead.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Surrey County Council")
-        },
-        {
-            "9075",
-            new LocalAuthorityDetails("Renfrewshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.renfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "6940",
-            new LocalAuthorityDetails("Rhondda Cynon Taf County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.rctcbc.gov.uk/Index.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2350",
-            new LocalAuthorityDetails("Ribble Valley Borough Council", LocalAuthorityStatus.Live,
-                "https://www.ribblevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "4225",
-            new LocalAuthorityDetails("Rochdale Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.rochdale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "1550",
-            new LocalAuthorityDetails("Rochford District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.rochford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "2355",
-            new LocalAuthorityDetails("Rossendale Borough Council", LocalAuthorityStatus.Live,
-                "https://www.rossendale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "1430",
-            new LocalAuthorityDetails("Rother District Council", LocalAuthorityStatus.Live,
-                "https://www.rother.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council")
-        },
-        {
-            "4415",
-            new LocalAuthorityDetails("Rotherham Metropolitan Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.rotherham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "5330",
-            new LocalAuthorityDetails("Royal Borough of Greenwich", LocalAuthorityStatus.Live,
-                "https://www.royalgreenwich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater London Authority")
-        },
-        {
-            "5600",
-            new LocalAuthorityDetails("Royal Borough of Kensington and Chelsea", LocalAuthorityStatus.Live,
-                "https://www.rbkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "5630",
-            new LocalAuthorityDetails("Royal Borough of Kingston upon Thames", LocalAuthorityStatus.Live,
-                "https://www.kingston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "355",
-            new LocalAuthorityDetails("Royal Borough of Windsor and Maidenhead", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "3715",
-            new LocalAuthorityDetails("Rugby Borough Council", LocalAuthorityStatus.Pending,
-                "https://www.rugby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "3630",
-            new LocalAuthorityDetails("Runnymede Borough Council", LocalAuthorityStatus.Live,
-                "https://www.runnymede.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "3040",
-            new LocalAuthorityDetails("Rushcliffe Borough Council", LocalAuthorityStatus.Live,
-                "https://www.rushcliffe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottinghamshire County Council")
-        },
-        {
-            "1750",
-            new LocalAuthorityDetails("Rushmoor Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "2470",
-            new LocalAuthorityDetails("Rutland County Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "4230",
-            new LocalAuthorityDetails("Salford City Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.salford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "4620",
-            new LocalAuthorityDetails("Sandwell Borough Council", LocalAuthorityStatus.Live,
-                "https://www.sandwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "9055",
-            new LocalAuthorityDetails("Scottish Borders Council", LocalAuthorityStatus.NoFunding,
-                "https://www.scotborders.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4320",
-            new LocalAuthorityDetails("Sefton Council", LocalAuthorityStatus.Live, "https://www.sefton.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
-        },
-        {
-            "2245",
-            new LocalAuthorityDetails("Sevenoaks District Council", LocalAuthorityStatus.Live,
-                "https://www.sevenoaks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4420",
-            new LocalAuthorityDetails("Sheffield City Council", LocalAuthorityStatus.Live,
-                "https://www.sheffield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9010",
-            new LocalAuthorityDetails("Shetland Islands Council", LocalAuthorityStatus.NoFunding,
-                "https://www.shetland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3245",
-            new LocalAuthorityDetails("Shropshire County Council", LocalAuthorityStatus.Live,
-                "https://www.shropshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Shropshire County Council")
-        },
-        {
-            "350",
-            new LocalAuthorityDetails("Slough Borough Council", LocalAuthorityStatus.Live, "https://www.slough.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4625",
-            new LocalAuthorityDetails("Solihull Borough Council", LocalAuthorityStatus.Live,
-                "https://www.solihull.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "3300",
-            new LocalAuthorityDetails("Somerset Council", LocalAuthorityStatus.Live, "https://www.somerset.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9076",
-            new LocalAuthorityDetails("South Ayrshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.south-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "530",
-            new LocalAuthorityDetails("South Cambridgeshire District Council", LocalAuthorityStatus.Live,
-                "https://www.scambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council")
-        },
-        {
-            "1040",
-            new LocalAuthorityDetails("South Derbyshire District Council", LocalAuthorityStatus.Live,
-                "https://www.southderbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "119",
-            new LocalAuthorityDetails("South Gloucestershire Council", LocalAuthorityStatus.Live,
-                "https://www.southglos.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "1125",
-            new LocalAuthorityDetails("South Hams District Council", LocalAuthorityStatus.Live,
-                "https://www.southhams.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Devon Borough Council")
-        },
-        {
-            "2525",
-            new LocalAuthorityDetails("South Holland District Council", LocalAuthorityStatus.Live,
-                "https://www.sholland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "East Lindsey District Council")
-        },
-        {
-            "2530",
-            new LocalAuthorityDetails("South Kesteven District Council", LocalAuthorityStatus.Live,
-                "https://www.southkesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
-        },
-        {
-            "9077",
-            new LocalAuthorityDetails("South Lanarkshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.southlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2630",
-            new LocalAuthorityDetails("South Norfolk District Council", LocalAuthorityStatus.Live,
-                "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Broadland District Council")
-        },
-        {
-            "3115",
-            new LocalAuthorityDetails("South Oxfordshire District Council", LocalAuthorityStatus.Live,
-                "https://www.southoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Oxfordshire County Council")
-        },
-        {
-            "2360",
-            new LocalAuthorityDetails("South Ribble Borough Council", LocalAuthorityStatus.Live,
-                "https://southribble.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "3430",
-            new LocalAuthorityDetails("South Staffordshire District Council", LocalAuthorityStatus.Live,
-                "https://www.sstaffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "4520",
-            new LocalAuthorityDetails("South Tyneside Council", LocalAuthorityStatus.Live,
-                "https://www.southtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1780",
-            new LocalAuthorityDetails("Southampton City Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1590",
-            new LocalAuthorityDetails("Southend-on-Sea Borough Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.southend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "5840",
-            new LocalAuthorityDetails("Southwark Council", LocalAuthorityStatus.Live, "https://www.southwark.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "3635",
-            new LocalAuthorityDetails("Spelthorne Borough Council", LocalAuthorityStatus.Live,
-                "https://www.spelthorne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "1930",
-            new LocalAuthorityDetails("St Albans City Council", LocalAuthorityStatus.Live,
-                "https://www.stalbans.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4315",
-            new LocalAuthorityDetails("St. Helens Borough Council", LocalAuthorityStatus.Live,
-                "https://www.sthelens.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Liverpool City Region Combined Authority")
-        },
-        {
-            "3425",
-            new LocalAuthorityDetails("Stafford Borough Council", LocalAuthorityStatus.Live,
-                "https://www.staffordbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "3435",
-            new LocalAuthorityDetails("Staffordshire Moorlands District Council", LocalAuthorityStatus.Live,
-                "https://www.staffsmoorlands.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "1935",
-            new LocalAuthorityDetails("Stevenage Borough Council", LocalAuthorityStatus.Live,
-                "https://www.stevenage.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9078",
-            new LocalAuthorityDetails("Stirling Council", LocalAuthorityStatus.NoFunding,
-                "https://www.stirling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4235",
-            new LocalAuthorityDetails("Stockport Metropolitan Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.stockport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "738",
-            new LocalAuthorityDetails("Stockton-on-Tees Borough Council", LocalAuthorityStatus.Live,
-                "https://www.stockton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Darlington Borough Council (Tees Consortium)")
-        },
-        {
-            "3455",
-            new LocalAuthorityDetails("Stoke-on-Trent City Council", LocalAuthorityStatus.Live,
-                "https://www.stoke.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "3720",
-            new LocalAuthorityDetails("Stratford-on-Avon District Council", LocalAuthorityStatus.Live,
-                "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council")
-        },
-        {
-            "1625",
-            new LocalAuthorityDetails("Stroud District Council", LocalAuthorityStatus.Live,
-                "https://www.stroud.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "3500",
-            new LocalAuthorityDetails("Suffolk County Council", LocalAuthorityStatus.Live,
-                "https://www.suffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
-        },
-        {
-            "4525",
-            new LocalAuthorityDetails("Sunderland City Council", LocalAuthorityStatus.Live,
-                "https://www.sunderland.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3600",
-            new LocalAuthorityDetails("Surrey County Council", LocalAuthorityStatus.Live,
-                "https://www.surreycc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "3640",
-            new LocalAuthorityDetails("Surrey Heath Borough Council", LocalAuthorityStatus.Live,
-                "https://www.surreyheath.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "2255",
-            new LocalAuthorityDetails("Swale Borough Council", LocalAuthorityStatus.NoFunding, "https://swale.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3935",
-            new LocalAuthorityDetails("Swindon Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.swindon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4240",
-            new LocalAuthorityDetails("Tameside Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.tameside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "3445",
-            new LocalAuthorityDetails("Tamworth Borough Council", LocalAuthorityStatus.Live,
-                "https://www.tamworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire")
-        },
-        {
-            "3645",
-            new LocalAuthorityDetails("Tandridge District Council", LocalAuthorityStatus.Live,
-                "https://www.tandridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "1130",
-            new LocalAuthorityDetails("Teignbridge District Council", LocalAuthorityStatus.Live,
-                "https://www.teignbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "3240",
-            new LocalAuthorityDetails("Telford and Wrekin Council", LocalAuthorityStatus.Live,
-                "https://www.telford.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000],
-                "Shropshire County Council")
-        },
-        {
-            "1560",
-            new LocalAuthorityDetails("Tendring District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.tendringdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "1760",
-            new LocalAuthorityDetails("Test Valley Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1630",
-            new LocalAuthorityDetails("Tewkesbury Borough Council", LocalAuthorityStatus.Live,
-                "https://tewkesbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council")
-        },
-        {
-            "2260",
-            new LocalAuthorityDetails("Thanet District Council", LocalAuthorityStatus.Live,
-                "https://www.thanet.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9068",
-            new LocalAuthorityDetails("The Highland Council", LocalAuthorityStatus.NoFunding,
-                "https://www.highland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "9071",
-            new LocalAuthorityDetails("The Moray Council", LocalAuthorityStatus.NoFunding, "http://www.moray.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1940",
-            new LocalAuthorityDetails("Three Rivers District Council", LocalAuthorityStatus.Live,
-                "https://www.threerivers.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council")
-        },
-        {
-            "1595",
-            new LocalAuthorityDetails("Thurrock Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.thurrock.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "2265",
-            new LocalAuthorityDetails("Tonbridge and Malling Borough Council",
-                LocalAuthorityStatus.NoLongerParticipating, "https://www.tmbc.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1165",
-            new LocalAuthorityDetails("Torbay Council", LocalAuthorityStatus.Live, "https://www.torbay.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "6945",
-            new LocalAuthorityDetails("Torfaen County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.torfaen.gov.uk/intro-splash.aspx", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1145",
-            new LocalAuthorityDetails("Torridge District Council", LocalAuthorityStatus.Live,
-                "https://www.torridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council")
-        },
-        {
-            "5900",
-            new LocalAuthorityDetails("Tower Hamlets Council", LocalAuthorityStatus.Live,
-                "https://www.towerhamlets.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater London Authority")
-        },
-        {
-            "4245",
-            new LocalAuthorityDetails("Trafford Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.trafford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "2270",
-            new LocalAuthorityDetails("Tunbridge Wells Borough Council", LocalAuthorityStatus.Live,
-                "https://tunbridgewells.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1570",
-            new LocalAuthorityDetails("Uttlesford District Council", LocalAuthorityStatus.ReferralsPaused,
-                "https://www.uttlesford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council")
-        },
-        {
-            "6950",
-            new LocalAuthorityDetails("Vale of Glamorgan Council", LocalAuthorityStatus.NoFunding,
-                "https://www.valeofglamorgan.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3120",
-            new LocalAuthorityDetails("Vale of White Horse District Council", LocalAuthorityStatus.Live,
-                "https://www.whitehorsedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Oxfordshire County Council")
-        },
-        {
-            "4725",
-            new LocalAuthorityDetails("Wakefield Council", LocalAuthorityStatus.Live, "https://www.wakefield.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "4630",
-            new LocalAuthorityDetails("Walsall Metropolitan Borough Council", LocalAuthorityStatus.Live,
-                "https://go.walsall.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "5960",
-            new LocalAuthorityDetails("Wandsworth London Borough Council", LocalAuthorityStatus.Live,
-                "https://www.wandsworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority")
-        },
-        {
-            "655",
-            new LocalAuthorityDetails("Warrington Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warrington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council")
-        },
-        {
-            "3725",
-            new LocalAuthorityDetails("Warwick District Council", LocalAuthorityStatus.Live,
-                "https://www.warwickdc.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000],
-                "Nottingham City Council")
-        },
-        {
-            "1945",
-            new LocalAuthorityDetails("Watford Borough Council", LocalAuthorityStatus.Live,
-                "https://www.watford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council")
-        },
-        {
-            "3650",
-            new LocalAuthorityDetails("Waverley Borough Council", LocalAuthorityStatus.Live,
-                "https://www.waverley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "1435",
-            new LocalAuthorityDetails("Wealden District Council", LocalAuthorityStatus.Live,
-                "https://www.wealden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1950",
-            new LocalAuthorityDetails("Welwyn Hatfield Borough Council", LocalAuthorityStatus.Live,
-                "https://www.welhat.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "340",
-            new LocalAuthorityDetails("West Berkshire Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "1150",
-            new LocalAuthorityDetails("West Devon Borough Council", LocalAuthorityStatus.Live,
-                "https://www.westdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Devon Borough Council")
-        },
-        {
-            "9057",
-            new LocalAuthorityDetails("West Dunbartonshire Council", LocalAuthorityStatus.NoFunding,
-                "https://www.west-dunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2365",
-            new LocalAuthorityDetails("West Lancashire District Council", LocalAuthorityStatus.Live,
-                "https://www.westlancs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "2535",
-            new LocalAuthorityDetails("West Lindsey District Council", LocalAuthorityStatus.Live,
-                "https://www.west-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire")
-        },
-        {
-            "9079",
-            new LocalAuthorityDetails("West Lothian Council", LocalAuthorityStatus.NoFunding,
-                "https://www.westlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "2845",
-            new LocalAuthorityDetails("West Northamptonshire Council", LocalAuthorityStatus.Live,
-                "https://www.westnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3125",
-            new LocalAuthorityDetails("West Oxfordshire District Council", LocalAuthorityStatus.Live,
-                "https://www.westoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council")
-        },
-        {
-            "3545",
-            new LocalAuthorityDetails("West Suffolk Council", LocalAuthorityStatus.Live,
-                "https://www.westsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council")
-        },
-        {
-            "5990",
-            new LocalAuthorityDetails("Westminster City Council", LocalAuthorityStatus.Live,
-                "https://www.westminster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater London Authority")
-        },
-        {
-            "935",
-            new LocalAuthorityDetails("Westmorland and Furness Council", LocalAuthorityStatus.Live,
-                "https://www.westmorlandandfurness.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "Westmorland and Furness Council")
-        },
-        {
-            "4250",
-            new LocalAuthorityDetails("Wigan Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating,
-                "https://www.wigan.gov.uk/index.aspx", IncomeBandOptions[IncomeThreshold._36000],
-                "Greater Manchester Combined Authority")
-        },
-        {
-            "3940",
-            new LocalAuthorityDetails("Wiltshire Council", LocalAuthorityStatus.Live, "https://www.wiltshire.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1765",
-            new LocalAuthorityDetails("Winchester City Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "4325",
-            new LocalAuthorityDetails("Wirral Council", LocalAuthorityStatus.Live, "https://www.wirral.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority")
-        },
-        {
-            "3655",
-            new LocalAuthorityDetails("Woking Borough Council", LocalAuthorityStatus.Live, "https://www.woking.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council")
-        },
-        {
-            "360",
-            new LocalAuthorityDetails("Wokingham Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "4635",
-            new LocalAuthorityDetails("Wolverhampton City Council", LocalAuthorityStatus.Live,
-                "https://www.wolverhampton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000],
-                "West Midlands Combined Authority")
-        },
-        {
-            "1835",
-            new LocalAuthorityDetails("Worcester City Council", LocalAuthorityStatus.Live,
-                "https://www.worcester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire")
-        },
-        {
-            "1855",
-            new LocalAuthorityDetails("Worcestershire County Council", LocalAuthorityStatus.NoFunding,
-                "https://www.worcestershire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "3835",
-            new LocalAuthorityDetails("Worthing Borough Council", LocalAuthorityStatus.Live,
-                "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council")
-        },
-        {
-            "6955",
-            new LocalAuthorityDetails("Wrexham County Borough Council", LocalAuthorityStatus.NoFunding,
-                "https://www.wrexham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        },
-        {
-            "1840",
-            new LocalAuthorityDetails("Wychavon District Council", LocalAuthorityStatus.Live,
-                "https://www.wychavon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire")
-        },
-        {
-            "2370",
-            new LocalAuthorityDetails("Wyre Borough Council", LocalAuthorityStatus.Live, "https://www.wyre.gov.uk/",
-                IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council")
-        },
-        {
-            "1845",
-            new LocalAuthorityDetails("Wyre Forest District Council", LocalAuthorityStatus.Live,
-                "https://www.wyreforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null)
-        }
+        { "9051", new LocalAuthorityDetails("Aberdeen City Council", LocalAuthorityStatus.NoFunding, "https://www.aberdeencity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9052", new LocalAuthorityDetails("Aberdeenshire Council", LocalAuthorityStatus.NoFunding, "https://www.aberdeenshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3805", new LocalAuthorityDetails("Adur District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1005", new LocalAuthorityDetails("Amber Valley Borough Council", LocalAuthorityStatus.Live, "https://www.ambervalley.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "9053", new LocalAuthorityDetails("Angus Council", LocalAuthorityStatus.NoFunding, "https://www.angus.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9054", new LocalAuthorityDetails("Argyll and Bute Council", LocalAuthorityStatus.NoFunding, "https://www.argyll-bute.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3810", new LocalAuthorityDetails("Arun District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "3005", new LocalAuthorityDetails("Ashfield District Council", LocalAuthorityStatus.Live, "https://www.ashfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
+        { "2205", new LocalAuthorityDetails("Ashford Borough Council", LocalAuthorityStatus.Live, "https://www.ashford.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3505", new LocalAuthorityDetails("Babergh District Council", LocalAuthorityStatus.Live, "https://www.babergh.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
+        { "5090", new LocalAuthorityDetails("Barnet Council", LocalAuthorityStatus.Live, "https://www.barnet.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "4405", new LocalAuthorityDetails("Barnsley Metropolitan Borough Council", LocalAuthorityStatus.Live, "https://www.barnsley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1505", new LocalAuthorityDetails("Basildon Council", LocalAuthorityStatus.Live, "https://www.basildon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1705", new LocalAuthorityDetails("Basingstoke and Deane Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "3010", new LocalAuthorityDetails("Bassetlaw District Council", LocalAuthorityStatus.Live, "https://www.bassetlaw.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "114", new LocalAuthorityDetails("Bath and North East Somerset Council", LocalAuthorityStatus.Live, "https://www.bathnes.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council") },
+        { "235", new LocalAuthorityDetails("Bedford Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "4605", new LocalAuthorityDetails("Birmingham City Council", LocalAuthorityStatus.Live, "https://www.birmingham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "2405", new LocalAuthorityDetails("Blaby District Council", LocalAuthorityStatus.Live, "https://www.blaby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
+        { "2372", new LocalAuthorityDetails("Blackburn with Darwen Borough Council", LocalAuthorityStatus.Live, "https://www.blackburn.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "2373", new LocalAuthorityDetails("Blackpool Council", LocalAuthorityStatus.Live, "https://www.blackpool.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "6910", new LocalAuthorityDetails("Blaenau Gwent County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.blaenau-gwent.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1010", new LocalAuthorityDetails("Bolsover District Council", LocalAuthorityStatus.Live, "https://www.bolsover.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "4205", new LocalAuthorityDetails("Bolton Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.bolton.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "2635", new LocalAuthorityDetails("Borough Council of King's Lynn & West Norfolk", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
+        { "1905", new LocalAuthorityDetails("Borough of Broxbourne Council", LocalAuthorityStatus.Live, "https://www.broxbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2505", new LocalAuthorityDetails("Boston Borough Council", LocalAuthorityStatus.Live, "https://www.boston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council") },
+        { "1260", new LocalAuthorityDetails("Bournemouth, Christchurch and Poole Council", LocalAuthorityStatus.ReferralsPaused, "https://www.bcpcouncil.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dorset Council") },
+        { "335", new LocalAuthorityDetails("Bracknell Forest Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1510", new LocalAuthorityDetails("Braintree District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.braintree.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "2605", new LocalAuthorityDetails("Breckland District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
+        { "5150", new LocalAuthorityDetails("Brent Council", LocalAuthorityStatus.Live, "https://www.brent.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "1515", new LocalAuthorityDetails("Brentwood Council", LocalAuthorityStatus.ReferralsPaused, "https://www.brentwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "6915", new LocalAuthorityDetails("Bridgend County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.bridgend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1445", new LocalAuthorityDetails("Brighton and Hove City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "116", new LocalAuthorityDetails("Bristol City Council", LocalAuthorityStatus.Live, "https://www.bristol.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council") },
+        { "2610", new LocalAuthorityDetails("Broadland District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
+        { "1805", new LocalAuthorityDetails("Bromsgrove District Council", LocalAuthorityStatus.Live, "https://www.bromsgrove.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "3015", new LocalAuthorityDetails("Broxtowe Borough Council", LocalAuthorityStatus.Live, "https://www.broxtowe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
+        { "440", new LocalAuthorityDetails("Buckinghamshire Council", LocalAuthorityStatus.Live, "https://www.buckinghamshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2315", new LocalAuthorityDetails("Burnley Borough Council", LocalAuthorityStatus.Live, "https://burnley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "4210", new LocalAuthorityDetails("Bury Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.bury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "6920", new LocalAuthorityDetails("Caerphilly County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.caerphilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4710", new LocalAuthorityDetails("Calderdale Council", LocalAuthorityStatus.Live, "https://new.calderdale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "505", new LocalAuthorityDetails("Cambridge City Council", LocalAuthorityStatus.Live, "https://www.cambridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
+        { "3405", new LocalAuthorityDetails("Cannock Chase District Council", LocalAuthorityStatus.Live, "https://www.cannockchasedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "2210", new LocalAuthorityDetails("Canterbury City Council", LocalAuthorityStatus.Live, "https://www.canterbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6825", new LocalAuthorityDetails("Carmarthenshire County Council", LocalAuthorityStatus.NoFunding, "https://www.carmarthenshire.gov.wales/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1520", new LocalAuthorityDetails("Castle Point District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.castlepoint.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "240", new LocalAuthorityDetails("Central Bedfordshire Council", LocalAuthorityStatus.Pending, "https://www.centralbedfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6820", new LocalAuthorityDetails("Ceredigion County Council", LocalAuthorityStatus.NoFunding, "https://www.ceredigion.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2410", new LocalAuthorityDetails("Charnwood Borough Council", LocalAuthorityStatus.Live, "https://www.charnwood.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
+        { "1525", new LocalAuthorityDetails("Chelmsford City Council", LocalAuthorityStatus.ReferralsPaused, "https://www.chelmsford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "1605", new LocalAuthorityDetails("Cheltenham Borough Council", LocalAuthorityStatus.Live, "https://www.cheltenham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "3105", new LocalAuthorityDetails("Cherwell District Council", LocalAuthorityStatus.Live, "https://www.cherwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
+        { "660", new LocalAuthorityDetails("Cheshire East Council", LocalAuthorityStatus.Live, "https://www.cheshireeast.gov.uk/home.aspx", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council") },
+        { "665", new LocalAuthorityDetails("Cheshire West and Chester Council", LocalAuthorityStatus.Live, "https://www.cheshirewestandchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council") },
+        { "1015", new LocalAuthorityDetails("Chesterfield Borough Council", LocalAuthorityStatus.Live, "https://www.chesterfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "3815", new LocalAuthorityDetails("Chichester District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "2320", new LocalAuthorityDetails("Chorley Borough Council", LocalAuthorityStatus.Live, "https://chorley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "6855", new LocalAuthorityDetails("City and County of Swansea Council", LocalAuthorityStatus.NoFunding, "https://www.swansea.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4705", new LocalAuthorityDetails("City of Bradford Metropolitan District Council", LocalAuthorityStatus.Pending, "https://www.bradford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6815", new LocalAuthorityDetails("City of Cardiff Council", LocalAuthorityStatus.NoFunding, "https://www.cardiff.gov.uk/ENG/Pages/default.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4410", new LocalAuthorityDetails("City of Doncaster Council", LocalAuthorityStatus.Live, "https://www.doncaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9064", new LocalAuthorityDetails("City of Edinburgh Council", LocalAuthorityStatus.NoFunding, "https://www.edinburgh.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "5030", new LocalAuthorityDetails("City of London Corporation", LocalAuthorityStatus.Live, "https://www.cityoflondon.gov.uk/about-us", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "2741", new LocalAuthorityDetails("City of York Council", LocalAuthorityStatus.Live, "https://www.york.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9056", new LocalAuthorityDetails("Clackmannanshire Council", LocalAuthorityStatus.NoFunding, "https://www.clacks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1530", new LocalAuthorityDetails("Colchester City Council", LocalAuthorityStatus.ReferralsPaused, "https://www.colchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "9020", new LocalAuthorityDetails("Comhairle nan Eilean Siar", LocalAuthorityStatus.NoFunding, "https://www.cne-siar.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6905", new LocalAuthorityDetails("Conwy County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.conwy.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "840", new LocalAuthorityDetails("Cornwall Council", LocalAuthorityStatus.Live, "https://www.cornwall.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council") },
+        { "1610", new LocalAuthorityDetails("Cotswold District Council", LocalAuthorityStatus.Live, "https://www.cotswold.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "4610", new LocalAuthorityDetails("Coventry City Council", LocalAuthorityStatus.Live, "https://www.coventry.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "3820", new LocalAuthorityDetails("Crawley Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "5240", new LocalAuthorityDetails("Croydon Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "940", new LocalAuthorityDetails("Cumberland Council", LocalAuthorityStatus.Live, "https://www.cumberland.gov.uk/housing/warm-homes/warm-homes-local-grant", IncomeBandOptions[IncomeThreshold._36000], "Westmorland and Furness Council") },
+        { "1910", new LocalAuthorityDetails("Dacorum Borough Council", LocalAuthorityStatus.Live, "https://www.dacorum.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1350", new LocalAuthorityDetails("Darlington Borough Council", LocalAuthorityStatus.Live, "https://www.darlington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
+        { "2215", new LocalAuthorityDetails("Dartford Borough Council", LocalAuthorityStatus.Live, "https://www.dartford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dover District Council") },
+        { "6830", new LocalAuthorityDetails("Denbighshire County Council", LocalAuthorityStatus.NoFunding, "https://www.denbighshire.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1055", new LocalAuthorityDetails("Derby City Council", LocalAuthorityStatus.Live, "https://www.derby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "1045", new LocalAuthorityDetails("Derbyshire Dales District Council", LocalAuthorityStatus.Live, "https://www.derbyshiredales.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "1155", new LocalAuthorityDetails("Devon County Council", LocalAuthorityStatus.Live, "https://www.devon.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "1265", new LocalAuthorityDetails("Dorset Council", LocalAuthorityStatus.ReferralsPaused, "https://www.dorsetcouncil.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Dorset Council") },
+        { "2220", new LocalAuthorityDetails("Dover District Council", LocalAuthorityStatus.Live, "https://www.dover.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000], "Dover District Council") },
+        { "4615", new LocalAuthorityDetails("Dudley Borough Council", LocalAuthorityStatus.Live, "https://www.dudley.gov.uk/residents/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "9058", new LocalAuthorityDetails("Dumfries and Galloway Council", LocalAuthorityStatus.NoFunding, "https://www.dumfriesandgalloway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9059", new LocalAuthorityDetails("Dundee City Council", LocalAuthorityStatus.NoFunding, "https://www.dundeecity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1355", new LocalAuthorityDetails("Durham County Council", LocalAuthorityStatus.Live, "https://www.durham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "5270", new LocalAuthorityDetails("Ealing Council", LocalAuthorityStatus.Live, "https://www.ealing.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "9060", new LocalAuthorityDetails("East Ayrshire Council", LocalAuthorityStatus.NoFunding, "https://www.east-ayrshire.gov.uk/Home.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "510", new LocalAuthorityDetails("East Cambridgeshire District Council", LocalAuthorityStatus.Live, "https://eastcambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
+        { "1105", new LocalAuthorityDetails("East Devon District Council", LocalAuthorityStatus.Live, "https://eastdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "9061", new LocalAuthorityDetails("East Dunbartonshire Council", LocalAuthorityStatus.NoFunding, "https://www.eastdunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1710", new LocalAuthorityDetails("East Hampshire District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1915", new LocalAuthorityDetails("East Hertfordshire District Council", LocalAuthorityStatus.Live, "https://www.eastherts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2510", new LocalAuthorityDetails("East Lindsey District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.e-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council") },
+        { "9062", new LocalAuthorityDetails("East Lothian Council", LocalAuthorityStatus.NoFunding, "https://www.eastlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9063", new LocalAuthorityDetails("East Renfrewshire Council", LocalAuthorityStatus.NoFunding, "https://www.eastrenfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2001", new LocalAuthorityDetails("East Riding of Yorkshire Council", LocalAuthorityStatus.ReferralsPaused, "https://www.eastriding.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3410", new LocalAuthorityDetails("East Staffordshire Borough Council", LocalAuthorityStatus.Live, "https://www.eaststaffsbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "3540", new LocalAuthorityDetails("East Suffolk Council", LocalAuthorityStatus.Live, "https://www.eastsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
+        { "1440", new LocalAuthorityDetails("East Sussex County Council", LocalAuthorityStatus.Live, "https://www.eastsussex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
+        { "1410", new LocalAuthorityDetails("Eastbourne Borough Council", LocalAuthorityStatus.Live, "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
+        { "1715", new LocalAuthorityDetails("Eastleigh Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "3605", new LocalAuthorityDetails("Elmbridge Borough Council", LocalAuthorityStatus.Live, "https://www.elmbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "5300", new LocalAuthorityDetails("Enfield Council", LocalAuthorityStatus.Live, "https://www.enfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "1535", new LocalAuthorityDetails("Epping Forest District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.eppingforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "3610", new LocalAuthorityDetails("Epsom and Ewell Borough Council", LocalAuthorityStatus.Live, "https://www.epsom-ewell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "1025", new LocalAuthorityDetails("Erewash Borough Council", LocalAuthorityStatus.Live, "https://www.erewash.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "1585", new LocalAuthorityDetails("Essex County Council", LocalAuthorityStatus.ReferralsPaused, "https://www.essex.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "1110", new LocalAuthorityDetails("Exeter City Council", LocalAuthorityStatus.Live, "https://exeter.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "9065", new LocalAuthorityDetails("Falkirk Council", LocalAuthorityStatus.NoFunding, "https://www.falkirk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1720", new LocalAuthorityDetails("Fareham Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "515", new LocalAuthorityDetails("Fenland District Council", LocalAuthorityStatus.Live, "https://www.fenland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
+        { "9066", new LocalAuthorityDetails("Fife Council", LocalAuthorityStatus.NoFunding, "https://www.fife.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6835", new LocalAuthorityDetails("Flintshire County Council", LocalAuthorityStatus.NoFunding, "https://www.flintshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2250", new LocalAuthorityDetails("Folkestone and Hythe District Council", LocalAuthorityStatus.NoFunding, "https://www.folkestone-hythe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1615", new LocalAuthorityDetails("Forest of Dean District Council", LocalAuthorityStatus.Live, "https://www.fdean.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "2325", new LocalAuthorityDetails("Fylde Borough Council", LocalAuthorityStatus.NoFunding, "https://new.fylde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4505", new LocalAuthorityDetails("Gateshead Council", LocalAuthorityStatus.Live, "https://www.gateshead.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3020", new LocalAuthorityDetails("Gedling Borough Council", LocalAuthorityStatus.Live, "https://www.gedling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
+        { "9067", new LocalAuthorityDetails("Glasgow City Council", LocalAuthorityStatus.NoFunding, "https://www.glasgow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1620", new LocalAuthorityDetails("Gloucester City Council", LocalAuthorityStatus.Live, "https://www.gloucester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "1725", new LocalAuthorityDetails("Gosport Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "2230", new LocalAuthorityDetails("Gravesham Borough Council", LocalAuthorityStatus.Live, "https://www.gravesham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2615", new LocalAuthorityDetails("Great Yarmouth Borough Council", LocalAuthorityStatus.Live, "https://www.great-yarmouth.gov.uk/welcome", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3615", new LocalAuthorityDetails("Guildford Borough Council", LocalAuthorityStatus.Live, "https://www.guildford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "6810", new LocalAuthorityDetails("Gwynedd Council", LocalAuthorityStatus.NoFunding, "https://www.gwynedd.llyw.cymru/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "5360", new LocalAuthorityDetails("Hackney Council", LocalAuthorityStatus.Live, "https://hackney.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "650", new LocalAuthorityDetails("Halton Borough Council", LocalAuthorityStatus.Live, "https://www3.halton.gov.uk", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
+        { "2415", new LocalAuthorityDetails("Harborough District Council", LocalAuthorityStatus.Live, "https://www.harborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
+        { "5420", new LocalAuthorityDetails("Haringey Council", LocalAuthorityStatus.Live, "https://www.haringey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "1540", new LocalAuthorityDetails("Harlow Council", LocalAuthorityStatus.ReferralsPaused, "https://www.harlow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "1730", new LocalAuthorityDetails("Hart District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "724", new LocalAuthorityDetails("Hartlepool Borough Council", LocalAuthorityStatus.Live, "https://www.hartlepool.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1415", new LocalAuthorityDetails("Hastings Borough Council", LocalAuthorityStatus.Live, "https://www.hastings.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
+        { "1735", new LocalAuthorityDetails("Havant Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1850", new LocalAuthorityDetails("Herefordshire Council", LocalAuthorityStatus.Live, "https://www.herefordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Shropshire County Council") },
+        { "1920", new LocalAuthorityDetails("Hertsmere Borough Council", LocalAuthorityStatus.NoFunding, "https://www.hertsmere.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1030", new LocalAuthorityDetails("High Peak Borough Council", LocalAuthorityStatus.Live, "https://www.highpeak.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "5510", new LocalAuthorityDetails("Hillingdon Council", LocalAuthorityStatus.Live, "https://www.hillingdon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "2420", new LocalAuthorityDetails("Hinckley and Bosworth Borough Council", LocalAuthorityStatus.Live, "https://www.hinckley-bosworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
+        { "3825", new LocalAuthorityDetails("Horsham District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "2004", new LocalAuthorityDetails("Hull City Council", LocalAuthorityStatus.Live, "https://www.hull.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "520", new LocalAuthorityDetails("Huntingdonshire District Council", LocalAuthorityStatus.Live, "https://www.huntingdonshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
+        { "2330", new LocalAuthorityDetails("Hyndburn Borough", LocalAuthorityStatus.Live, "https://www.hyndburnbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "9069", new LocalAuthorityDetails("Inverclyde Council", LocalAuthorityStatus.NoFunding, "https://www.inverclyde.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3515", new LocalAuthorityDetails("Ipswich Borough Council", LocalAuthorityStatus.Live, "https://www.ipswich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
+        { "6805", new LocalAuthorityDetails("Isle of Anglesey County Council", LocalAuthorityStatus.NoFunding, "https://www.anglesey.gov.uk/Cyngor-Sir-Ynys-Mon-Isle-of-Anglesey-County-Council.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2114", new LocalAuthorityDetails("Isle of Wight Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "835", new LocalAuthorityDetails("Isles of Scilly Council", LocalAuthorityStatus.Live, "https://www.scilly.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cornwall Council") },
+        { "5570", new LocalAuthorityDetails("Islington Council", LocalAuthorityStatus.Live, "https://www.islington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "4715", new LocalAuthorityDetails("Kirklees Council", LocalAuthorityStatus.NoFunding, "https://www.kirklees.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4305", new LocalAuthorityDetails("Knowsley Council", LocalAuthorityStatus.Live, "https://www.knowsley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
+        { "5660", new LocalAuthorityDetails("Lambeth Council", LocalAuthorityStatus.Live, "https://www.lambeth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "2335", new LocalAuthorityDetails("Lancaster City Council", LocalAuthorityStatus.Live, "https://www.lancaster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "4720", new LocalAuthorityDetails("Leeds City Council", LocalAuthorityStatus.Live, "https://www.leeds.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2465", new LocalAuthorityDetails("Leicester City Council", LocalAuthorityStatus.Live, "https://www.leicester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1425", new LocalAuthorityDetails("Lewes District Council", LocalAuthorityStatus.Live, "https://www.lewes-eastbourne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
+        { "5690", new LocalAuthorityDetails("Lewisham Council", LocalAuthorityStatus.Live, "https://lewisham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "3415", new LocalAuthorityDetails("Lichfield City Council", LocalAuthorityStatus.Live, "https://www.lichfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "2515", new LocalAuthorityDetails("Lincoln City Council", LocalAuthorityStatus.Live, "https://www.lincoln.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
+        { "4310", new LocalAuthorityDetails("Liverpool City Council", LocalAuthorityStatus.Live, "https://liverpool.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
+        { "5060", new LocalAuthorityDetails("London Borough of Barking and Dagenham", LocalAuthorityStatus.Live, "https://www.lbbd.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "5120", new LocalAuthorityDetails("London Borough of Bexley", LocalAuthorityStatus.Live, "https://www.bexley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5180", new LocalAuthorityDetails("London Borough of Bromley", LocalAuthorityStatus.Live, "https://www.bromley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5210", new LocalAuthorityDetails("London Borough of Camden", LocalAuthorityStatus.Live, "https://www.camden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5390", new LocalAuthorityDetails("London Borough of Hammersmith and Fulham", LocalAuthorityStatus.Live, "https://www.lbhf.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5450", new LocalAuthorityDetails("London Borough of Harrow", LocalAuthorityStatus.Live, "https://www.harrow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5480", new LocalAuthorityDetails("London Borough of Havering", LocalAuthorityStatus.Live, "https://www.havering.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5540", new LocalAuthorityDetails("London Borough of Hounslow", LocalAuthorityStatus.Live, "https://www.hounslow.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5720", new LocalAuthorityDetails("London Borough of Merton", LocalAuthorityStatus.Live, "https://www.merton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5780", new LocalAuthorityDetails("London Borough of Redbridge", LocalAuthorityStatus.Live, "https://www.redbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5810", new LocalAuthorityDetails("London Borough of Richmond upon Thames", LocalAuthorityStatus.Live, "https://www.richmond.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5870", new LocalAuthorityDetails("London Borough of Sutton", LocalAuthorityStatus.Live, "https://sutton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5930", new LocalAuthorityDetails("London Borough of Waltham Forest", LocalAuthorityStatus.Live, "https://www.walthamforest.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "230", new LocalAuthorityDetails("Luton Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "2235", new LocalAuthorityDetails("Maidstone Borough Council", LocalAuthorityStatus.NoFunding, "https://maidstone.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1545", new LocalAuthorityDetails("Maldon District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.maldon.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "1820", new LocalAuthorityDetails("Malvern Hills District Council", LocalAuthorityStatus.Live, "https://www.malvernhills.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire") },
+        { "4215", new LocalAuthorityDetails("Manchester City Council", LocalAuthorityStatus.NotParticipating, "https://www.manchester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "3025", new LocalAuthorityDetails("Mansfield District Council", LocalAuthorityStatus.Live, "https://www.mansfield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "2280", new LocalAuthorityDetails("Medway Council", LocalAuthorityStatus.NoLongerParticipating, "https://www.medway.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2430", new LocalAuthorityDetails("Melton Borough Council", LocalAuthorityStatus.Live, "https://www.melton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
+        { "6925", new LocalAuthorityDetails("Merthyr Tydfil County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.merthyr.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1135", new LocalAuthorityDetails("Mid Devon District Council", LocalAuthorityStatus.Live, "https://www.middevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "3520", new LocalAuthorityDetails("Mid Suffolk District Council", LocalAuthorityStatus.Live, "https://www.midsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
+        { "3830", new LocalAuthorityDetails("Mid Sussex District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "734", new LocalAuthorityDetails("Middlesbrough Council", LocalAuthorityStatus.Live, "https://www.middlesbrough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
+        { "9070", new LocalAuthorityDetails("Midlothian Council", LocalAuthorityStatus.NoFunding, "https://www.midlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "435", new LocalAuthorityDetails("Milton Keynes Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "3620", new LocalAuthorityDetails("Mole Valley District Council", LocalAuthorityStatus.Live, "https://www.molevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "6840", new LocalAuthorityDetails("Monmouthshire County Council", LocalAuthorityStatus.NoFunding, "https://www.monmouthshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6930", new LocalAuthorityDetails("Neath Port Talbot County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.npt.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1740", new LocalAuthorityDetails("New Forest District Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "3030", new LocalAuthorityDetails("Newark and Sherwood District Council", LocalAuthorityStatus.Live, "https://www.newark-sherwooddc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
+        { "4510", new LocalAuthorityDetails("Newcastle City Council", LocalAuthorityStatus.Live, "https://www.newcastle.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3420", new LocalAuthorityDetails("Newcastle-under-Lyme Borough Council", LocalAuthorityStatus.Live, "https://www.newcastle-staffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "5750", new LocalAuthorityDetails("Newham Council", LocalAuthorityStatus.Live, "https://www.newham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "6935", new LocalAuthorityDetails("Newport City Council", LocalAuthorityStatus.NoFunding, "https://www.newport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9072", new LocalAuthorityDetails("North Ayrshire Council", LocalAuthorityStatus.NoFunding, "https://www.north-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1115", new LocalAuthorityDetails("North Devon District Council", LocalAuthorityStatus.Live, "https://www.northdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "1035", new LocalAuthorityDetails("North East Derbyshire District Council", LocalAuthorityStatus.Live, "https://www.ne-derbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2002", new LocalAuthorityDetails("North East Lincolnshire Council", LocalAuthorityStatus.Live, "https://www.nelincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "1925", new LocalAuthorityDetails("North Hertfordshire District Council", LocalAuthorityStatus.Live, "https://www.north-herts.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2520", new LocalAuthorityDetails("North Kesteven District Council", LocalAuthorityStatus.Live, "https://www.n-kesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
+        { "9073", new LocalAuthorityDetails("North Lanarkshire Council", LocalAuthorityStatus.NoFunding, "https://www.northlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2003", new LocalAuthorityDetails("North Lincolnshire Council", LocalAuthorityStatus.Live, "https://www.northlincs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "2620", new LocalAuthorityDetails("North Norfolk District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
+        { "2840", new LocalAuthorityDetails("North Northamptonshire Council", LocalAuthorityStatus.Live, "https://www.northnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "121", new LocalAuthorityDetails("North Somerset Council", LocalAuthorityStatus.Live, "https://n-somerset.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Bristol City Council") },
+        { "4515", new LocalAuthorityDetails("North Tyneside Council", LocalAuthorityStatus.Live, "https://my.northtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3705", new LocalAuthorityDetails("North Warwickshire Borough Council", LocalAuthorityStatus.Live, "https://www.northwarks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "2435", new LocalAuthorityDetails("North West Leicestershire District Council", LocalAuthorityStatus.Live, "https://www.nwleics.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Leicestershire") },
+        { "2745", new LocalAuthorityDetails("North Yorkshire Council", LocalAuthorityStatus.Live, "https://www.northyorks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2935", new LocalAuthorityDetails("Northumberland County Council", LocalAuthorityStatus.Live, "https://www.northumberland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2625", new LocalAuthorityDetails("Norwich City Council", LocalAuthorityStatus.Live, "https://www.norwich.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3060", new LocalAuthorityDetails("Nottingham City Council", LocalAuthorityStatus.Live, "https://www.nottinghamcity.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "3710", new LocalAuthorityDetails("Nuneaton and Bedworth Borough Council", LocalAuthorityStatus.Live, "https://www.nuneatonandbedworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "2440", new LocalAuthorityDetails("Oadby and Wigston Borough Council", LocalAuthorityStatus.Live, "https://www.oadby-wigston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "4220", new LocalAuthorityDetails("Oldham Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.oldham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "9000", new LocalAuthorityDetails("Orkney Islands Council", LocalAuthorityStatus.NoFunding, "https://www.orkney.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3110", new LocalAuthorityDetails("Oxford City Council", LocalAuthorityStatus.Live, "https://www.oxford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
+        { "3100", new LocalAuthorityDetails("Oxfordshire County Council", LocalAuthorityStatus.Live, "https://www.oxfordshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
+        { "6845", new LocalAuthorityDetails("Pembrokeshire County Council", LocalAuthorityStatus.NoFunding, "https://www.pembrokeshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2340", new LocalAuthorityDetails("Pendle Borough Council", LocalAuthorityStatus.Live, "https://www.pendle.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "9074", new LocalAuthorityDetails("Perth and Kinross Council", LocalAuthorityStatus.NoFunding, "https://www.pkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "540", new LocalAuthorityDetails("Peterborough City Council", LocalAuthorityStatus.Live, "https://www.peterborough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
+        { "1160", new LocalAuthorityDetails("Plymouth City Council", LocalAuthorityStatus.Live, "https://www.plymouth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1775", new LocalAuthorityDetails("Portsmouth City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "6850", new LocalAuthorityDetails("Powys County Council", LocalAuthorityStatus.NoFunding, "https://www.powys.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2345", new LocalAuthorityDetails("Preston City Council", LocalAuthorityStatus.Live, "https://www.preston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "345", new LocalAuthorityDetails("Reading Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "728", new LocalAuthorityDetails("Redcar and Cleveland Borough", LocalAuthorityStatus.Live, "https://www.redcar-cleveland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
+        { "1825", new LocalAuthorityDetails("Redditch Borough Council", LocalAuthorityStatus.Live, "https://www.redditchbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "3625", new LocalAuthorityDetails("Reigate and Banstead Borough Council", LocalAuthorityStatus.Live, "https://www.reigate-banstead.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "9075", new LocalAuthorityDetails("Renfrewshire Council", LocalAuthorityStatus.NoFunding, "https://www.renfrewshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "6940", new LocalAuthorityDetails("Rhondda Cynon Taf County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.rctcbc.gov.uk/Index.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2350", new LocalAuthorityDetails("Ribble Valley Borough Council", LocalAuthorityStatus.Live, "https://www.ribblevalley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "4225", new LocalAuthorityDetails("Rochdale Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.rochdale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "1550", new LocalAuthorityDetails("Rochford District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.rochford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "2355", new LocalAuthorityDetails("Rossendale Borough Council", LocalAuthorityStatus.Live, "https://www.rossendale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "1430", new LocalAuthorityDetails("Rother District Council", LocalAuthorityStatus.Live, "https://www.rother.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Lewes District Council") },
+        { "4415", new LocalAuthorityDetails("Rotherham Metropolitan Borough Council", LocalAuthorityStatus.NoFunding, "https://www.rotherham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "5330", new LocalAuthorityDetails("Royal Borough of Greenwich", LocalAuthorityStatus.Live, "https://www.royalgreenwich.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5600", new LocalAuthorityDetails("Royal Borough of Kensington and Chelsea", LocalAuthorityStatus.Live, "https://www.rbkc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "5630", new LocalAuthorityDetails("Royal Borough of Kingston upon Thames", LocalAuthorityStatus.Live, "https://www.kingston.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "355", new LocalAuthorityDetails("Royal Borough of Windsor and Maidenhead", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "3715", new LocalAuthorityDetails("Rugby Borough Council", LocalAuthorityStatus.Pending, "https://www.rugby.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "3630", new LocalAuthorityDetails("Runnymede Borough Council", LocalAuthorityStatus.Live, "https://www.runnymede.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "3040", new LocalAuthorityDetails("Rushcliffe Borough Council", LocalAuthorityStatus.Live, "https://www.rushcliffe.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottinghamshire County Council") },
+        { "1750", new LocalAuthorityDetails("Rushmoor Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "2470", new LocalAuthorityDetails("Rutland County Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "4230", new LocalAuthorityDetails("Salford City Council", LocalAuthorityStatus.NotParticipating, "https://www.salford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "4620", new LocalAuthorityDetails("Sandwell Borough Council", LocalAuthorityStatus.Live, "https://www.sandwell.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "9055", new LocalAuthorityDetails("Scottish Borders Council", LocalAuthorityStatus.NoFunding, "https://www.scotborders.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4320", new LocalAuthorityDetails("Sefton Council", LocalAuthorityStatus.Live, "https://www.sefton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
+        { "2245", new LocalAuthorityDetails("Sevenoaks District Council", LocalAuthorityStatus.Live, "https://www.sevenoaks.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4420", new LocalAuthorityDetails("Sheffield City Council", LocalAuthorityStatus.Live, "https://www.sheffield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9010", new LocalAuthorityDetails("Shetland Islands Council", LocalAuthorityStatus.NoFunding, "https://www.shetland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3245", new LocalAuthorityDetails("Shropshire County Council", LocalAuthorityStatus.Live, "https://www.shropshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Shropshire County Council") },
+        { "350", new LocalAuthorityDetails("Slough Borough Council", LocalAuthorityStatus.Live, "https://www.slough.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4625", new LocalAuthorityDetails("Solihull Borough Council", LocalAuthorityStatus.Live, "https://www.solihull.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "3300", new LocalAuthorityDetails("Somerset Council", LocalAuthorityStatus.Live, "https://www.somerset.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9076", new LocalAuthorityDetails("South Ayrshire Council", LocalAuthorityStatus.NoFunding, "https://www.south-ayrshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "530", new LocalAuthorityDetails("South Cambridgeshire District Council", LocalAuthorityStatus.Live, "https://www.scambs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cambridge City Council") },
+        { "1040", new LocalAuthorityDetails("South Derbyshire District Council", LocalAuthorityStatus.Live, "https://www.southderbyshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "119", new LocalAuthorityDetails("South Gloucestershire Council", LocalAuthorityStatus.Live, "https://www.southglos.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "1125", new LocalAuthorityDetails("South Hams District Council", LocalAuthorityStatus.Live, "https://www.southhams.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Devon Borough Council") },
+        { "2525", new LocalAuthorityDetails("South Holland District Council", LocalAuthorityStatus.Live, "https://www.sholland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "East Lindsey District Council") },
+        { "2530", new LocalAuthorityDetails("South Kesteven District Council", LocalAuthorityStatus.Live, "https://www.southkesteven.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
+        { "9077", new LocalAuthorityDetails("South Lanarkshire Council", LocalAuthorityStatus.NoFunding, "https://www.southlanarkshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2630", new LocalAuthorityDetails("South Norfolk District Council", LocalAuthorityStatus.Live, "https://norfolkwarmhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Broadland District Council") },
+        { "3115", new LocalAuthorityDetails("South Oxfordshire District Council", LocalAuthorityStatus.Live, "https://www.southoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
+        { "2360", new LocalAuthorityDetails("South Ribble Borough Council", LocalAuthorityStatus.Live, "https://southribble.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "3430", new LocalAuthorityDetails("South Staffordshire District Council", LocalAuthorityStatus.Live, "https://www.sstaffs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "4520", new LocalAuthorityDetails("South Tyneside Council", LocalAuthorityStatus.Live, "https://www.southtyneside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1780", new LocalAuthorityDetails("Southampton City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1590", new LocalAuthorityDetails("Southend-on-Sea Borough Council", LocalAuthorityStatus.ReferralsPaused, "https://www.southend.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "5840", new LocalAuthorityDetails("Southwark Council", LocalAuthorityStatus.Live, "https://www.southwark.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "3635", new LocalAuthorityDetails("Spelthorne Borough Council", LocalAuthorityStatus.Live, "https://www.spelthorne.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "1930", new LocalAuthorityDetails("St Albans City Council", LocalAuthorityStatus.Live, "https://www.stalbans.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4315", new LocalAuthorityDetails("St. Helens Borough Council", LocalAuthorityStatus.Live, "https://www.sthelens.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
+        { "3425", new LocalAuthorityDetails("Stafford Borough Council", LocalAuthorityStatus.Live, "https://www.staffordbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "3435", new LocalAuthorityDetails("Staffordshire Moorlands District Council", LocalAuthorityStatus.Live, "https://www.staffsmoorlands.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "1935", new LocalAuthorityDetails("Stevenage Borough Council", LocalAuthorityStatus.Live, "https://www.stevenage.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9078", new LocalAuthorityDetails("Stirling Council", LocalAuthorityStatus.NoFunding, "https://www.stirling.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4235", new LocalAuthorityDetails("Stockport Metropolitan Borough Council", LocalAuthorityStatus.NoFunding, "https://www.stockport.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "738", new LocalAuthorityDetails("Stockton-on-Tees Borough Council", LocalAuthorityStatus.Live, "https://www.stockton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Darlington Borough Council (Tees Consortium)") },
+        { "3455", new LocalAuthorityDetails("Stoke-on-Trent City Council", LocalAuthorityStatus.Live, "https://www.stoke.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "3720", new LocalAuthorityDetails("Stratford-on-Avon District Council", LocalAuthorityStatus.Live, "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "1625", new LocalAuthorityDetails("Stroud District Council", LocalAuthorityStatus.Live, "https://www.stroud.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "3500", new LocalAuthorityDetails("Suffolk County Council", LocalAuthorityStatus.Live, "https://www.suffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
+        { "4525", new LocalAuthorityDetails("Sunderland City Council", LocalAuthorityStatus.Live, "https://www.sunderland.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3600", new LocalAuthorityDetails("Surrey County Council", LocalAuthorityStatus.Live, "https://www.surreycc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "3640", new LocalAuthorityDetails("Surrey Heath Borough Council", LocalAuthorityStatus.Live, "https://www.surreyheath.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "2255", new LocalAuthorityDetails("Swale Borough Council", LocalAuthorityStatus.NoFunding, "https://swale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3935", new LocalAuthorityDetails("Swindon Borough Council", LocalAuthorityStatus.NoFunding, "https://www.swindon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4240", new LocalAuthorityDetails("Tameside Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.tameside.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "3445", new LocalAuthorityDetails("Tamworth Borough Council", LocalAuthorityStatus.Live, "https://www.tamworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Staffordshire") },
+        { "3645", new LocalAuthorityDetails("Tandridge District Council", LocalAuthorityStatus.Live, "https://www.tandridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "1130", new LocalAuthorityDetails("Teignbridge District Council", LocalAuthorityStatus.Live, "https://www.teignbridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "3240", new LocalAuthorityDetails("Telford and Wrekin Council", LocalAuthorityStatus.Live, "https://www.telford.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Shropshire County Council") },
+        { "1560", new LocalAuthorityDetails("Tendring District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.tendringdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "1760", new LocalAuthorityDetails("Test Valley Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1630", new LocalAuthorityDetails("Tewkesbury Borough Council", LocalAuthorityStatus.Live, "https://tewkesbury.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
+        { "2260", new LocalAuthorityDetails("Thanet District Council", LocalAuthorityStatus.Live, "https://www.thanet.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9068", new LocalAuthorityDetails("The Highland Council", LocalAuthorityStatus.NoFunding, "https://www.highland.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "9071", new LocalAuthorityDetails("The Moray Council", LocalAuthorityStatus.NoFunding, "http://www.moray.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1940", new LocalAuthorityDetails("Three Rivers District Council", LocalAuthorityStatus.Live, "https://www.threerivers.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council") },
+        { "1595", new LocalAuthorityDetails("Thurrock Council", LocalAuthorityStatus.ReferralsPaused, "https://www.thurrock.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "2265", new LocalAuthorityDetails("Tonbridge and Malling Borough Council", LocalAuthorityStatus.NoLongerParticipating, "https://www.tmbc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1165", new LocalAuthorityDetails("Torbay Council", LocalAuthorityStatus.Live, "https://www.torbay.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "6945", new LocalAuthorityDetails("Torfaen County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.torfaen.gov.uk/intro-splash.aspx", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1145", new LocalAuthorityDetails("Torridge District Council", LocalAuthorityStatus.Live, "https://www.torridge.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Devon County Council") },
+        { "5900", new LocalAuthorityDetails("Tower Hamlets Council", LocalAuthorityStatus.Live, "https://www.towerhamlets.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "4245", new LocalAuthorityDetails("Trafford Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.trafford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "2270", new LocalAuthorityDetails("Tunbridge Wells Borough Council", LocalAuthorityStatus.Live, "https://tunbridgewells.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1570", new LocalAuthorityDetails("Uttlesford District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.uttlesford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Essex County Council") },
+        { "6950", new LocalAuthorityDetails("Vale of Glamorgan Council", LocalAuthorityStatus.NoFunding, "https://www.valeofglamorgan.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3120", new LocalAuthorityDetails("Vale of White Horse District Council", LocalAuthorityStatus.Live, "https://www.whitehorsedc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
+        { "4725", new LocalAuthorityDetails("Wakefield Council", LocalAuthorityStatus.Live, "https://www.wakefield.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4630", new LocalAuthorityDetails("Walsall Metropolitan Borough Council", LocalAuthorityStatus.Live, "https://go.walsall.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "5960", new LocalAuthorityDetails("Wandsworth London Borough Council", LocalAuthorityStatus.Live, "https://www.wandsworth.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "655", new LocalAuthorityDetails("Warrington Borough Council", LocalAuthorityStatus.Live, "https://www.warrington.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Cheshire East Council") },
+        { "3725", new LocalAuthorityDetails("Warwick District Council", LocalAuthorityStatus.Live, "https://www.warwickdc.gov.uk/site/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
+        { "1945", new LocalAuthorityDetails("Watford Borough Council", LocalAuthorityStatus.Live, "https://www.watford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Watford Borough Council") },
+        { "3650", new LocalAuthorityDetails("Waverley Borough Council", LocalAuthorityStatus.Live, "https://www.waverley.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "1435", new LocalAuthorityDetails("Wealden District Council", LocalAuthorityStatus.Live, "https://www.wealden.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1950", new LocalAuthorityDetails("Welwyn Hatfield Borough Council", LocalAuthorityStatus.Live, "https://www.welhat.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "340", new LocalAuthorityDetails("West Berkshire Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "1150", new LocalAuthorityDetails("West Devon Borough Council", LocalAuthorityStatus.Live, "https://www.westdevon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Devon Borough Council") },
+        { "9057", new LocalAuthorityDetails("West Dunbartonshire Council", LocalAuthorityStatus.NoFunding, "https://www.west-dunbarton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2365", new LocalAuthorityDetails("West Lancashire District Council", LocalAuthorityStatus.Live, "https://www.westlancs.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "2535", new LocalAuthorityDetails("West Lindsey District Council", LocalAuthorityStatus.Live, "https://www.west-lindsey.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Central Lincolnshire") },
+        { "9079", new LocalAuthorityDetails("West Lothian Council", LocalAuthorityStatus.NoFunding, "https://www.westlothian.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "2845", new LocalAuthorityDetails("West Northamptonshire Council", LocalAuthorityStatus.Live, "https://www.westnorthants.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3125", new LocalAuthorityDetails("West Oxfordshire District Council", LocalAuthorityStatus.Live, "https://www.westoxon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Oxfordshire County Council") },
+        { "3545", new LocalAuthorityDetails("West Suffolk Council", LocalAuthorityStatus.Live, "https://www.westsuffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
+        { "5990", new LocalAuthorityDetails("Westminster City Council", LocalAuthorityStatus.Live, "https://www.westminster.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Greater London Authority") },
+        { "935", new LocalAuthorityDetails("Westmorland and Furness Council", LocalAuthorityStatus.Live, "https://www.westmorlandandfurness.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Westmorland and Furness Council") },
+        { "4250", new LocalAuthorityDetails("Wigan Metropolitan Borough Council", LocalAuthorityStatus.NotParticipating, "https://www.wigan.gov.uk/index.aspx", IncomeBandOptions[IncomeThreshold._36000], "Greater Manchester Combined Authority") },
+        { "3940", new LocalAuthorityDetails("Wiltshire Council", LocalAuthorityStatus.Live, "https://www.wiltshire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1765", new LocalAuthorityDetails("Winchester City Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "4325", new LocalAuthorityDetails("Wirral Council", LocalAuthorityStatus.Live, "https://www.wirral.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Liverpool City Region Combined Authority") },
+        { "3655", new LocalAuthorityDetails("Woking Borough Council", LocalAuthorityStatus.Live, "https://www.woking.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
+        { "360", new LocalAuthorityDetails("Wokingham Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "4635", new LocalAuthorityDetails("Wolverhampton City Council", LocalAuthorityStatus.Live, "https://www.wolverhampton.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "West Midlands Combined Authority") },
+        { "1835", new LocalAuthorityDetails("Worcester City Council", LocalAuthorityStatus.Live, "https://www.worcester.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire") },
+        { "1855", new LocalAuthorityDetails("Worcestershire County Council", LocalAuthorityStatus.NoFunding, "https://www.worcestershire.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "3835", new LocalAuthorityDetails("Worthing Borough Council", LocalAuthorityStatus.Live, "https://www.warmerhomes.org.uk/", IncomeBandOptions[IncomeThreshold._36000], "Portsmouth City Council") },
+        { "6955", new LocalAuthorityDetails("Wrexham County Borough Council", LocalAuthorityStatus.NoFunding, "https://www.wrexham.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "1840", new LocalAuthorityDetails("Wychavon District Council", LocalAuthorityStatus.Live, "https://www.wychavon.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Worcestershire") },
+        { "2370", new LocalAuthorityDetails("Wyre Borough Council", LocalAuthorityStatus.Live, "https://www.wyre.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Blackpool Council") },
+        { "1845", new LocalAuthorityDetails("Wyre Forest District Council", LocalAuthorityStatus.Live, "https://www.wyreforestdc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },
     };
 
     public static readonly IEnumerable<string> LiveWmcaCustodianCodes = FilterCustodianCodes(
         ConsortiumNames.WestMidlandsCombinedAuthority,
         LocalAuthorityStatus.Live);
-
-    public static readonly IReadOnlyList<string> ManagedByLcrcaCodes = new[] { "650", "4305", "4315", "4325" };
-
-    public static IEnumerable<string> FilterCustodianCodes(
-        string consortium,
-        LocalAuthorityStatus? status = null)
-    {
-        return LocalAuthorityDetailsByCustodianCode
-            .Where(localAuthority =>
-                localAuthority.Value.Consortium == consortium &&
-                (status == null || localAuthority.Value.Status == status))
-            .Select(localAuthority => localAuthority.Key)
-            .ToList();
-    }
 
     public static bool CustodianCodeIsInConsortium(string custodianCode, string consortium)
     {
@@ -1909,27 +427,17 @@ public class LocalAuthorityData
                localAuthority.Consortium == consortium;
     }
 
+    public static readonly IReadOnlyList<string> ManagedByLcrcaCodes = new[] { "650", "4305", "4315", "4325" };
+    
     public static bool CustodianCodeIsManagedByLcrca(string custodianCode)
     {
-        return
-            CustodianCodeIsInConsortium(custodianCode, ConsortiumNames.LiverpoolCityRegionCombinedAuthority)
+        return 
+            CustodianCodeIsInConsortium(custodianCode, ConsortiumNames.LiverpoolCityRegionCombinedAuthority) 
             // not all LAs in the LCRCA are managed by the LCRCA, so we must filter further to
             // Halton
             // Knowsley
             // St Helens
             // Wirral
             && ManagedByLcrcaCodes.Contains(custodianCode);
-    }
-
-    public record LocalAuthorityDetails(
-        string Name,
-        LocalAuthorityStatus Status,
-        string WebsiteUrl,
-        IncomeBand[] IncomeBandOptions,
-        string? Consortium);
-
-    private enum IncomeThreshold
-    {
-        _36000
     }
 }

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CustomWordingConsistencyTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CustomWordingConsistencyTests.cs
@@ -1,0 +1,156 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using WhlgPublicWebsite.BusinessLogic.Models;
+
+namespace Tests.BusinessLogic.Services;
+
+[TestFixture]
+public class CustomWordingConsistencyTests
+{
+    // If any of these tests start failing, an LA with custom view partials or email overrides
+    // has likely changed status. Review whether the custom wordings for that LA are still correct,
+    // update any wording if necessary, then update the expected status in this list. 
+    // It may also be the case that there is a new consortium with custom wordings, or that the LAs 
+    // that are part of a consortium have changed. In this case, update the list
+    // and the LaCodesWithCustomWordings_ContainsExactlyAllLasWithCustomWordings test
+    private static readonly (string CustodianCode, LocalAuthorityData.LocalAuthorityStatus ExpectedStatus)[]
+        LaCodesWithCustomWordings =
+        [
+            // West Midlands Combined Authority (custom: Eligible, Confirmation, NotParticipating, email template)
+            ("4605", LocalAuthorityData.LocalAuthorityStatus.Live),   // Birmingham City Council
+            ("4610", LocalAuthorityData.LocalAuthorityStatus.Live),   // Coventry City Council
+            ("4615", LocalAuthorityData.LocalAuthorityStatus.Live),   // Dudley Borough Council
+            ("4620", LocalAuthorityData.LocalAuthorityStatus.Live),   // Sandwell Borough Council
+            ("4625", LocalAuthorityData.LocalAuthorityStatus.Live),   // Solihull Borough Council
+            ("4630", LocalAuthorityData.LocalAuthorityStatus.Live),   // Walsall Metropolitan Borough Council
+            ("4635", LocalAuthorityData.LocalAuthorityStatus.Live),   // Wolverhampton City Council
+             
+            // Broadland District Council (custom: Eligible, Confirmation)
+            ("2610", LocalAuthorityData.LocalAuthorityStatus.Live),   // Broadland District Council
+            ("2605", LocalAuthorityData.LocalAuthorityStatus.Live),   // Breckland District Council
+            ("2635", LocalAuthorityData.LocalAuthorityStatus.Live),   // Borough Council of King's Lynn & West Norfolk
+            ("2620", LocalAuthorityData.LocalAuthorityStatus.Live),   // North Norfolk District Council
+            ("2630", LocalAuthorityData.LocalAuthorityStatus.Live),   // South Norfolk District Council
+             
+            // Portsmouth City Council (custom: Eligible, Confirmation, email overrides)
+            ("1775", LocalAuthorityData.LocalAuthorityStatus.Live),   // Portsmouth City Council
+            ("3805", LocalAuthorityData.LocalAuthorityStatus.Live),   // Adur District Council
+            ("3810", LocalAuthorityData.LocalAuthorityStatus.Live),   // Arun District Council
+            ("1705", LocalAuthorityData.LocalAuthorityStatus.Live),   // Basingstoke and Deane Borough Council
+            ("235",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Bedford Borough Council
+            ("335",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Bracknell Forest Borough Council
+            ("1445", LocalAuthorityData.LocalAuthorityStatus.Live),   // Brighton and Hove City Council
+            ("3815", LocalAuthorityData.LocalAuthorityStatus.Live),   // Chichester District Council
+            ("3820", LocalAuthorityData.LocalAuthorityStatus.Live),   // Crawley Borough Council
+            ("5240", LocalAuthorityData.LocalAuthorityStatus.Live),   // Croydon Council
+            ("1710", LocalAuthorityData.LocalAuthorityStatus.Live),   // East Hampshire District Council
+            ("1715", LocalAuthorityData.LocalAuthorityStatus.Live),   // Eastleigh Borough Council
+            ("1720", LocalAuthorityData.LocalAuthorityStatus.Live),   // Fareham Borough Council
+            ("1725", LocalAuthorityData.LocalAuthorityStatus.Live),   // Gosport Borough Council
+            ("1730", LocalAuthorityData.LocalAuthorityStatus.Live),   // Hart District Council
+            ("1735", LocalAuthorityData.LocalAuthorityStatus.Live),   // Havant Borough Council
+            ("3825", LocalAuthorityData.LocalAuthorityStatus.Live),   // Horsham District Council
+            ("2114", LocalAuthorityData.LocalAuthorityStatus.Live),   // Isle of Wight Council
+            ("230",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Luton Borough Council
+            ("435",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Milton Keynes Council
+            ("3830", LocalAuthorityData.LocalAuthorityStatus.Live),   // Mid Sussex District Council
+            ("1740", LocalAuthorityData.LocalAuthorityStatus.Live),   // New Forest District Council
+            ("345",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Reading Borough Council
+            ("355",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Windsor and Maidenhead
+            ("1750", LocalAuthorityData.LocalAuthorityStatus.Live),   // Rushmoor Borough Council
+            ("2470", LocalAuthorityData.LocalAuthorityStatus.Live),   // Rutland County Council
+            ("1780", LocalAuthorityData.LocalAuthorityStatus.Live),   // Southampton City Council
+            ("1760", LocalAuthorityData.LocalAuthorityStatus.Live),   // Test Valley Borough Council
+            ("340",  LocalAuthorityData.LocalAuthorityStatus.Live),   // West Berkshire Council
+            ("1765", LocalAuthorityData.LocalAuthorityStatus.Live),   // Winchester City Council
+            ("360",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Wokingham Borough Council
+            ("3835", LocalAuthorityData.LocalAuthorityStatus.Live),   // Worthing Borough Council
+             
+            // Greater London Authority (custom: Eligible, Confirmation, ReferralsPaused, email overrides)
+            ("5090", LocalAuthorityData.LocalAuthorityStatus.Live),   // Barnet Council
+            ("5150", LocalAuthorityData.LocalAuthorityStatus.Live),   // Brent Council
+            ("5180", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Bromley
+            ("5210", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Camden
+            ("5030", LocalAuthorityData.LocalAuthorityStatus.Live),   // City of London Corporation
+            ("5270", LocalAuthorityData.LocalAuthorityStatus.Live),   // Ealing Council
+            ("5300", LocalAuthorityData.LocalAuthorityStatus.Live),   // Enfield Council
+            ("5360", LocalAuthorityData.LocalAuthorityStatus.Live),   // Hackney Council
+            ("5420", LocalAuthorityData.LocalAuthorityStatus.Live),   // Haringey Council
+            ("5450", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Harrow
+            ("5480", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Havering
+            ("5510", LocalAuthorityData.LocalAuthorityStatus.Live),   // Hillingdon Council
+            ("5540", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Hounslow
+            ("5570", LocalAuthorityData.LocalAuthorityStatus.Live),   // Islington Council
+            ("5120", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Bexley
+            ("5660", LocalAuthorityData.LocalAuthorityStatus.Live),   // Lambeth Council
+            ("5690", LocalAuthorityData.LocalAuthorityStatus.Live),   // Lewisham Council
+            ("5390", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Hammersmith and Fulham
+            ("5720", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Merton
+            ("5750", LocalAuthorityData.LocalAuthorityStatus.Live),   // Newham Council
+            ("5780", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Redbridge
+            ("5810", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Richmond upon Thames
+            ("5330", LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Greenwich
+            ("5600", LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Kensington and Chelsea
+            ("5630", LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Kingston upon Thames
+            ("5840", LocalAuthorityData.LocalAuthorityStatus.Live),   // Southwark Council
+            ("5870", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Sutton
+            ("5900", LocalAuthorityData.LocalAuthorityStatus.Live),   // Tower Hamlets Council
+            ("5960", LocalAuthorityData.LocalAuthorityStatus.Live),   // Wandsworth London Borough Council
+            ("5990", LocalAuthorityData.LocalAuthorityStatus.Live),   // Westminster City Council
+             
+            // Oxfordshire County Council (custom: Eligible, email overrides)
+            ("3100", LocalAuthorityData.LocalAuthorityStatus.Live),   // Oxfordshire County Council
+            ("3105", LocalAuthorityData.LocalAuthorityStatus.Live),   // Cherwell District Council
+            ("3110", LocalAuthorityData.LocalAuthorityStatus.Live),   // Oxford City Council
+            ("3115", LocalAuthorityData.LocalAuthorityStatus.Live),   // South Oxfordshire District Council
+            ("3120", LocalAuthorityData.LocalAuthorityStatus.Live),   // Vale of White Horse District Council
+            ("3125", LocalAuthorityData.LocalAuthorityStatus.Live),   // West Oxfordshire District Council
+             
+            // Liverpool City Region Combined Authority - managed only (custom: Eligible)
+            ("650",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Halton Borough Council
+            ("4305", LocalAuthorityData.LocalAuthorityStatus.Live),   // Knowsley Council
+            ("4315", LocalAuthorityData.LocalAuthorityStatus.Live),   // St. Helens Borough Council
+            ("4325", LocalAuthorityData.LocalAuthorityStatus.Live),   // Wirral Council
+             
+            // Greater Manchester Combined Authority (custom: NotParticipating)
+            ("4205", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Bolton Metropolitan Borough Council
+            ("4210", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Bury Metropolitan Borough Council
+            ("4215", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Manchester City Council
+            ("4220", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Oldham Metropolitan Borough Council
+            ("4225", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Rochdale Metropolitan Borough Council
+            ("4230", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Salford City Council
+            ("4240", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Tameside Metropolitan Borough Council
+            ("4245", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Trafford Metropolitan Borough Council
+            ("4250", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Wigan Metropolitan Borough Council
+        ];
+    
+    [Test]
+    public void LaCodesWithCustomWordings_ContainsExactlyAllLasWithCustomWordings()
+    {
+        var expectedCodes = new HashSet<string>(
+            LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.WestMidlandsCombinedAuthority)
+                .Concat(LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.BroadlandDistrictCouncil))
+                .Concat(LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.PortsmouthCityCouncil))
+                .Concat(LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.GreaterLondonAuthority))
+                .Concat(LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.OxfordshireCountyCouncil))
+                .Concat(LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.GreaterManchesterCombinedAuthority))
+                .Concat(LocalAuthorityData.ManagedByLcrcaCodes)
+        );
+ 
+        var actualCodes = new HashSet<string>(
+            LaCodesWithCustomWordings.Select(t => t.CustodianCode)
+        );
+ 
+        actualCodes.Should().BeEquivalentTo(expectedCodes);
+    }
+ 
+    [TestCaseSource(nameof(LaCodesWithCustomWordings))]
+    public void LocalAuthorityWithCustomWordingHasExpectedStatus(
+        (string CustodianCode, LocalAuthorityData.LocalAuthorityStatus ExpectedStatus) testCase)
+    {
+        LocalAuthorityData.LocalAuthorityDetailsByCustodianCode[testCase.CustodianCode].Status
+            .Should().Be(testCase.ExpectedStatus);
+    }
+}

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CustomWordingConsistencyTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/CustomWordingConsistencyTests.cs
@@ -19,113 +19,113 @@ public class CustomWordingConsistencyTests
         LaCodesWithCustomWordings =
         [
             // West Midlands Combined Authority (custom: Eligible, Confirmation, NotParticipating, email template)
-            ("4605", LocalAuthorityData.LocalAuthorityStatus.Live),   // Birmingham City Council
-            ("4610", LocalAuthorityData.LocalAuthorityStatus.Live),   // Coventry City Council
-            ("4615", LocalAuthorityData.LocalAuthorityStatus.Live),   // Dudley Borough Council
-            ("4620", LocalAuthorityData.LocalAuthorityStatus.Live),   // Sandwell Borough Council
-            ("4625", LocalAuthorityData.LocalAuthorityStatus.Live),   // Solihull Borough Council
-            ("4630", LocalAuthorityData.LocalAuthorityStatus.Live),   // Walsall Metropolitan Borough Council
-            ("4635", LocalAuthorityData.LocalAuthorityStatus.Live),   // Wolverhampton City Council
-             
+            ("4605", LocalAuthorityData.LocalAuthorityStatus.Live), // Birmingham City Council
+            ("4610", LocalAuthorityData.LocalAuthorityStatus.Live), // Coventry City Council
+            ("4615", LocalAuthorityData.LocalAuthorityStatus.Live), // Dudley Borough Council
+            ("4620", LocalAuthorityData.LocalAuthorityStatus.Live), // Sandwell Borough Council
+            ("4625", LocalAuthorityData.LocalAuthorityStatus.Live), // Solihull Borough Council
+            ("4630", LocalAuthorityData.LocalAuthorityStatus.Live), // Walsall Metropolitan Borough Council
+            ("4635", LocalAuthorityData.LocalAuthorityStatus.Live), // Wolverhampton City Council
+
             // Broadland District Council (custom: Eligible, Confirmation)
-            ("2610", LocalAuthorityData.LocalAuthorityStatus.Live),   // Broadland District Council
-            ("2605", LocalAuthorityData.LocalAuthorityStatus.Live),   // Breckland District Council
-            ("2635", LocalAuthorityData.LocalAuthorityStatus.Live),   // Borough Council of King's Lynn & West Norfolk
-            ("2620", LocalAuthorityData.LocalAuthorityStatus.Live),   // North Norfolk District Council
-            ("2630", LocalAuthorityData.LocalAuthorityStatus.Live),   // South Norfolk District Council
-             
+            ("2610", LocalAuthorityData.LocalAuthorityStatus.Live), // Broadland District Council
+            ("2605", LocalAuthorityData.LocalAuthorityStatus.Live), // Breckland District Council
+            ("2635", LocalAuthorityData.LocalAuthorityStatus.Live), // Borough Council of King's Lynn & West Norfolk
+            ("2620", LocalAuthorityData.LocalAuthorityStatus.Live), // North Norfolk District Council
+            ("2630", LocalAuthorityData.LocalAuthorityStatus.Live), // South Norfolk District Council
+
             // Portsmouth City Council (custom: Eligible, Confirmation, email overrides)
-            ("1775", LocalAuthorityData.LocalAuthorityStatus.Live),   // Portsmouth City Council
-            ("3805", LocalAuthorityData.LocalAuthorityStatus.Live),   // Adur District Council
-            ("3810", LocalAuthorityData.LocalAuthorityStatus.Live),   // Arun District Council
-            ("1705", LocalAuthorityData.LocalAuthorityStatus.Live),   // Basingstoke and Deane Borough Council
-            ("235",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Bedford Borough Council
-            ("335",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Bracknell Forest Borough Council
-            ("1445", LocalAuthorityData.LocalAuthorityStatus.Live),   // Brighton and Hove City Council
-            ("3815", LocalAuthorityData.LocalAuthorityStatus.Live),   // Chichester District Council
-            ("3820", LocalAuthorityData.LocalAuthorityStatus.Live),   // Crawley Borough Council
-            ("5240", LocalAuthorityData.LocalAuthorityStatus.Live),   // Croydon Council
-            ("1710", LocalAuthorityData.LocalAuthorityStatus.Live),   // East Hampshire District Council
-            ("1715", LocalAuthorityData.LocalAuthorityStatus.Live),   // Eastleigh Borough Council
-            ("1720", LocalAuthorityData.LocalAuthorityStatus.Live),   // Fareham Borough Council
-            ("1725", LocalAuthorityData.LocalAuthorityStatus.Live),   // Gosport Borough Council
-            ("1730", LocalAuthorityData.LocalAuthorityStatus.Live),   // Hart District Council
-            ("1735", LocalAuthorityData.LocalAuthorityStatus.Live),   // Havant Borough Council
-            ("3825", LocalAuthorityData.LocalAuthorityStatus.Live),   // Horsham District Council
-            ("2114", LocalAuthorityData.LocalAuthorityStatus.Live),   // Isle of Wight Council
-            ("230",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Luton Borough Council
-            ("435",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Milton Keynes Council
-            ("3830", LocalAuthorityData.LocalAuthorityStatus.Live),   // Mid Sussex District Council
-            ("1740", LocalAuthorityData.LocalAuthorityStatus.Live),   // New Forest District Council
-            ("345",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Reading Borough Council
-            ("355",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Windsor and Maidenhead
-            ("1750", LocalAuthorityData.LocalAuthorityStatus.Live),   // Rushmoor Borough Council
-            ("2470", LocalAuthorityData.LocalAuthorityStatus.Live),   // Rutland County Council
-            ("1780", LocalAuthorityData.LocalAuthorityStatus.Live),   // Southampton City Council
-            ("1760", LocalAuthorityData.LocalAuthorityStatus.Live),   // Test Valley Borough Council
-            ("340",  LocalAuthorityData.LocalAuthorityStatus.Live),   // West Berkshire Council
-            ("1765", LocalAuthorityData.LocalAuthorityStatus.Live),   // Winchester City Council
-            ("360",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Wokingham Borough Council
-            ("3835", LocalAuthorityData.LocalAuthorityStatus.Live),   // Worthing Borough Council
-             
+            ("1775", LocalAuthorityData.LocalAuthorityStatus.Live), // Portsmouth City Council
+            ("3805", LocalAuthorityData.LocalAuthorityStatus.Live), // Adur District Council
+            ("3810", LocalAuthorityData.LocalAuthorityStatus.Live), // Arun District Council
+            ("1705", LocalAuthorityData.LocalAuthorityStatus.Live), // Basingstoke and Deane Borough Council
+            ("235", LocalAuthorityData.LocalAuthorityStatus.Live), // Bedford Borough Council
+            ("335", LocalAuthorityData.LocalAuthorityStatus.Live), // Bracknell Forest Borough Council
+            ("1445", LocalAuthorityData.LocalAuthorityStatus.Live), // Brighton and Hove City Council
+            ("3815", LocalAuthorityData.LocalAuthorityStatus.Live), // Chichester District Council
+            ("3820", LocalAuthorityData.LocalAuthorityStatus.Live), // Crawley Borough Council
+            ("5240", LocalAuthorityData.LocalAuthorityStatus.Live), // Croydon Council
+            ("1710", LocalAuthorityData.LocalAuthorityStatus.Live), // East Hampshire District Council
+            ("1715", LocalAuthorityData.LocalAuthorityStatus.Live), // Eastleigh Borough Council
+            ("1720", LocalAuthorityData.LocalAuthorityStatus.Live), // Fareham Borough Council
+            ("1725", LocalAuthorityData.LocalAuthorityStatus.Live), // Gosport Borough Council
+            ("1730", LocalAuthorityData.LocalAuthorityStatus.Live), // Hart District Council
+            ("1735", LocalAuthorityData.LocalAuthorityStatus.Live), // Havant Borough Council
+            ("3825", LocalAuthorityData.LocalAuthorityStatus.Live), // Horsham District Council
+            ("2114", LocalAuthorityData.LocalAuthorityStatus.Live), // Isle of Wight Council
+            ("230", LocalAuthorityData.LocalAuthorityStatus.Live), // Luton Borough Council
+            ("435", LocalAuthorityData.LocalAuthorityStatus.Live), // Milton Keynes Council
+            ("3830", LocalAuthorityData.LocalAuthorityStatus.Live), // Mid Sussex District Council
+            ("1740", LocalAuthorityData.LocalAuthorityStatus.Live), // New Forest District Council
+            ("345", LocalAuthorityData.LocalAuthorityStatus.Live), // Reading Borough Council
+            ("355", LocalAuthorityData.LocalAuthorityStatus.Live), // Royal Borough of Windsor and Maidenhead
+            ("1750", LocalAuthorityData.LocalAuthorityStatus.Live), // Rushmoor Borough Council
+            ("2470", LocalAuthorityData.LocalAuthorityStatus.Live), // Rutland County Council
+            ("1780", LocalAuthorityData.LocalAuthorityStatus.Live), // Southampton City Council
+            ("1760", LocalAuthorityData.LocalAuthorityStatus.Live), // Test Valley Borough Council
+            ("340", LocalAuthorityData.LocalAuthorityStatus.Live), // West Berkshire Council
+            ("1765", LocalAuthorityData.LocalAuthorityStatus.Live), // Winchester City Council
+            ("360", LocalAuthorityData.LocalAuthorityStatus.Live), // Wokingham Borough Council
+            ("3835", LocalAuthorityData.LocalAuthorityStatus.Live), // Worthing Borough Council
+
             // Greater London Authority (custom: Eligible, Confirmation, ReferralsPaused, email overrides)
-            ("5090", LocalAuthorityData.LocalAuthorityStatus.Live),   // Barnet Council
-            ("5150", LocalAuthorityData.LocalAuthorityStatus.Live),   // Brent Council
-            ("5180", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Bromley
-            ("5210", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Camden
-            ("5030", LocalAuthorityData.LocalAuthorityStatus.Live),   // City of London Corporation
-            ("5270", LocalAuthorityData.LocalAuthorityStatus.Live),   // Ealing Council
-            ("5300", LocalAuthorityData.LocalAuthorityStatus.Live),   // Enfield Council
-            ("5360", LocalAuthorityData.LocalAuthorityStatus.Live),   // Hackney Council
-            ("5420", LocalAuthorityData.LocalAuthorityStatus.Live),   // Haringey Council
-            ("5450", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Harrow
-            ("5480", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Havering
-            ("5510", LocalAuthorityData.LocalAuthorityStatus.Live),   // Hillingdon Council
-            ("5540", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Hounslow
-            ("5570", LocalAuthorityData.LocalAuthorityStatus.Live),   // Islington Council
-            ("5120", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Bexley
-            ("5660", LocalAuthorityData.LocalAuthorityStatus.Live),   // Lambeth Council
-            ("5690", LocalAuthorityData.LocalAuthorityStatus.Live),   // Lewisham Council
-            ("5390", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Hammersmith and Fulham
-            ("5720", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Merton
-            ("5750", LocalAuthorityData.LocalAuthorityStatus.Live),   // Newham Council
-            ("5780", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Redbridge
-            ("5810", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Richmond upon Thames
-            ("5330", LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Greenwich
-            ("5600", LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Kensington and Chelsea
-            ("5630", LocalAuthorityData.LocalAuthorityStatus.Live),   // Royal Borough of Kingston upon Thames
-            ("5840", LocalAuthorityData.LocalAuthorityStatus.Live),   // Southwark Council
-            ("5870", LocalAuthorityData.LocalAuthorityStatus.Live),   // London Borough of Sutton
-            ("5900", LocalAuthorityData.LocalAuthorityStatus.Live),   // Tower Hamlets Council
-            ("5960", LocalAuthorityData.LocalAuthorityStatus.Live),   // Wandsworth London Borough Council
-            ("5990", LocalAuthorityData.LocalAuthorityStatus.Live),   // Westminster City Council
-             
+            ("5090", LocalAuthorityData.LocalAuthorityStatus.Live), // Barnet Council
+            ("5150", LocalAuthorityData.LocalAuthorityStatus.Live), // Brent Council
+            ("5180", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Bromley
+            ("5210", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Camden
+            ("5030", LocalAuthorityData.LocalAuthorityStatus.Live), // City of London Corporation
+            ("5270", LocalAuthorityData.LocalAuthorityStatus.Live), // Ealing Council
+            ("5300", LocalAuthorityData.LocalAuthorityStatus.Live), // Enfield Council
+            ("5360", LocalAuthorityData.LocalAuthorityStatus.Live), // Hackney Council
+            ("5420", LocalAuthorityData.LocalAuthorityStatus.Live), // Haringey Council
+            ("5450", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Harrow
+            ("5480", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Havering
+            ("5510", LocalAuthorityData.LocalAuthorityStatus.Live), // Hillingdon Council
+            ("5540", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Hounslow
+            ("5570", LocalAuthorityData.LocalAuthorityStatus.Live), // Islington Council
+            ("5120", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Bexley
+            ("5660", LocalAuthorityData.LocalAuthorityStatus.Live), // Lambeth Council
+            ("5690", LocalAuthorityData.LocalAuthorityStatus.Live), // Lewisham Council
+            ("5390", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Hammersmith and Fulham
+            ("5720", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Merton
+            ("5750", LocalAuthorityData.LocalAuthorityStatus.Live), // Newham Council
+            ("5780", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Redbridge
+            ("5810", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Richmond upon Thames
+            ("5330", LocalAuthorityData.LocalAuthorityStatus.Live), // Royal Borough of Greenwich
+            ("5600", LocalAuthorityData.LocalAuthorityStatus.Live), // Royal Borough of Kensington and Chelsea
+            ("5630", LocalAuthorityData.LocalAuthorityStatus.Live), // Royal Borough of Kingston upon Thames
+            ("5840", LocalAuthorityData.LocalAuthorityStatus.Live), // Southwark Council
+            ("5870", LocalAuthorityData.LocalAuthorityStatus.Live), // London Borough of Sutton
+            ("5900", LocalAuthorityData.LocalAuthorityStatus.Live), // Tower Hamlets Council
+            ("5960", LocalAuthorityData.LocalAuthorityStatus.Live), // Wandsworth London Borough Council
+            ("5990", LocalAuthorityData.LocalAuthorityStatus.Live), // Westminster City Council
+
             // Oxfordshire County Council (custom: Eligible, email overrides)
-            ("3100", LocalAuthorityData.LocalAuthorityStatus.Live),   // Oxfordshire County Council
-            ("3105", LocalAuthorityData.LocalAuthorityStatus.Live),   // Cherwell District Council
-            ("3110", LocalAuthorityData.LocalAuthorityStatus.Live),   // Oxford City Council
-            ("3115", LocalAuthorityData.LocalAuthorityStatus.Live),   // South Oxfordshire District Council
-            ("3120", LocalAuthorityData.LocalAuthorityStatus.Live),   // Vale of White Horse District Council
-            ("3125", LocalAuthorityData.LocalAuthorityStatus.Live),   // West Oxfordshire District Council
-             
+            ("3100", LocalAuthorityData.LocalAuthorityStatus.Live), // Oxfordshire County Council
+            ("3105", LocalAuthorityData.LocalAuthorityStatus.Live), // Cherwell District Council
+            ("3110", LocalAuthorityData.LocalAuthorityStatus.Live), // Oxford City Council
+            ("3115", LocalAuthorityData.LocalAuthorityStatus.Live), // South Oxfordshire District Council
+            ("3120", LocalAuthorityData.LocalAuthorityStatus.Live), // Vale of White Horse District Council
+            ("3125", LocalAuthorityData.LocalAuthorityStatus.Live), // West Oxfordshire District Council
+
             // Liverpool City Region Combined Authority - managed only (custom: Eligible)
-            ("650",  LocalAuthorityData.LocalAuthorityStatus.Live),   // Halton Borough Council
-            ("4305", LocalAuthorityData.LocalAuthorityStatus.Live),   // Knowsley Council
-            ("4315", LocalAuthorityData.LocalAuthorityStatus.Live),   // St. Helens Borough Council
-            ("4325", LocalAuthorityData.LocalAuthorityStatus.Live),   // Wirral Council
-             
+            ("650", LocalAuthorityData.LocalAuthorityStatus.Live), // Halton Borough Council
+            ("4305", LocalAuthorityData.LocalAuthorityStatus.Live), // Knowsley Council
+            ("4315", LocalAuthorityData.LocalAuthorityStatus.Live), // St. Helens Borough Council
+            ("4325", LocalAuthorityData.LocalAuthorityStatus.Live), // Wirral Council
+
             // Greater Manchester Combined Authority (custom: NotParticipating)
-            ("4205", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Bolton Metropolitan Borough Council
-            ("4210", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Bury Metropolitan Borough Council
-            ("4215", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Manchester City Council
-            ("4220", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Oldham Metropolitan Borough Council
-            ("4225", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Rochdale Metropolitan Borough Council
-            ("4230", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Salford City Council
-            ("4240", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Tameside Metropolitan Borough Council
-            ("4245", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Trafford Metropolitan Borough Council
-            ("4250", LocalAuthorityData.LocalAuthorityStatus.NotParticipating),   // Wigan Metropolitan Borough Council
+            ("4205", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Bolton Metropolitan Borough Council
+            ("4210", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Bury Metropolitan Borough Council
+            ("4215", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Manchester City Council
+            ("4220", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Oldham Metropolitan Borough Council
+            ("4225", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Rochdale Metropolitan Borough Council
+            ("4230", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Salford City Council
+            ("4240", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Tameside Metropolitan Borough Council
+            ("4245", LocalAuthorityData.LocalAuthorityStatus.NotParticipating), // Trafford Metropolitan Borough Council
+            ("4250", LocalAuthorityData.LocalAuthorityStatus.NotParticipating) // Wigan Metropolitan Borough Council
         ];
-    
+
     [Test]
     public void LaCodesWithCustomWordings_ContainsExactlyAllLasWithCustomWordings()
     {
@@ -138,14 +138,14 @@ public class CustomWordingConsistencyTests
                 .Concat(LocalAuthorityData.FilterCustodianCodes(ConsortiumNames.GreaterManchesterCombinedAuthority))
                 .Concat(LocalAuthorityData.ManagedByLcrcaCodes)
         );
- 
+
         var actualCodes = new HashSet<string>(
             LaCodesWithCustomWordings.Select(t => t.CustodianCode)
         );
- 
+
         actualCodes.Should().BeEquivalentTo(expectedCodes);
     }
- 
+
     [TestCaseSource(nameof(LaCodesWithCustomWordings))]
     public void LocalAuthorityWithCustomWordingHasExpectedStatus(
         (string CustodianCode, LocalAuthorityData.LocalAuthorityStatus ExpectedStatus) testCase)

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/QuestionFlowServiceTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Services/QuestionFlowServiceTests.cs
@@ -73,6 +73,8 @@ public class QuestionFlowServiceTests
         // 1. Update this test's name to reflect if this LocalAuthorityStatus exists within the LA data
         // 2. Search the project for "DESNZ-1849" for all references to this status and ensure they are updated to reflect the test name statement
         // 3. Invert the test assertion to correctly assert the statement in the test name (i.e. Throw should become NotThrow and vice versa)
+        // Note: the wording on the TakingFutureReferrals mentions 'spring 2025'. The wording/date here and in other places that mention 
+        // old dates should be reviewed
         Action act = () =>
             LocalAuthorityDataHelper.GetExampleCustodianCodeForStatus(LocalAuthorityData.LocalAuthorityStatus
                 .TakingFutureReferrals);

--- a/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
@@ -1087,6 +1087,12 @@ public class QuestionnaireController : Controller
                 (LocalAuthorityData.LocalAuthorityStatus.Live, var custodianCode) when LocalAuthorityData
                         .CustodianCodeIsInConsortium(custodianCode, ConsortiumNames.GreaterLondonAuthority) =>
                     "GreaterLondonAuthority",
+                (LocalAuthorityData.LocalAuthorityStatus.Live, var custodianCode) when LocalAuthorityData
+                        .CustodianCodeIsInConsortium(custodianCode, ConsortiumNames.OxfordshireCountyCouncil) =>
+                    "OxfordshireCountyCouncil",
+                (LocalAuthorityData.LocalAuthorityStatus.Live, var custodianCode) when LocalAuthorityData
+                        .CustodianCodeIsManagedByLcrca(custodianCode) =>
+                    "LiverpoolCityRegionCombinedAuthority",
                 _ => "Default"
             };
         return $"~/Views/Partials/LocalAuthorityMessages/Confirmation/{partialViewName}.cshtml";

--- a/WhlgPublicWebsite/Views/Partials/LocalAuthorityMessages/Confirmation/LiverpoolCityRegionCombinedAuthority.cshtml
+++ b/WhlgPublicWebsite/Views/Partials/LocalAuthorityMessages/Confirmation/LiverpoolCityRegionCombinedAuthority.cshtml
@@ -1,0 +1,22 @@
+@using GovUkDesignSystem
+@using GovUkDesignSystem.GovUkDesignSystemComponents
+@model WhlgPublicWebsite.Models.Questionnaire.ConfirmationViewModel
+
+<p class="govuk-body">
+    <strong>Liverpool City Region Combined Authority or their official contractor</strong> will process
+    your details and should contact you within 10 working days.
+<p class="govuk-body">
+
+<p class="govuk-body">
+    @if (Model.LocalAuthorityIsLive)
+    {
+        @await Html.GovUkInsetText(new InsetTextViewModel
+        {
+            Text = "If you do not receive a response within 10 working days, please contact Liverpool City Region Combined Authority directly."
+        })
+    }
+</p>
+
+<p class="govuk-body">To enquire about your application visit <a class="govuk-link"
+                                                                 href="https://www.liverpoolcityregion-ca.gov.uk/warm-homes-local-grant">Liverpool
+        City Region Combined Authority's website</a>.</p>

--- a/WhlgPublicWebsite/Views/Partials/LocalAuthorityMessages/Confirmation/OxfordshireCountyCouncil.cshtml
+++ b/WhlgPublicWebsite/Views/Partials/LocalAuthorityMessages/Confirmation/OxfordshireCountyCouncil.cshtml
@@ -1,0 +1,22 @@
+@using GovUkDesignSystem
+@using GovUkDesignSystem.GovUkDesignSystemComponents
+@model WhlgPublicWebsite.Models.Questionnaire.ConfirmationViewModel
+
+<p class="govuk-body">
+    <strong>Oxfordshire County Council or their official contractor</strong> will process
+    your details and should contact you within 10 working days.
+<p class="govuk-body">
+
+<p class="govuk-body">
+    @if (Model.LocalAuthorityIsLive)
+    {
+        @await Html.GovUkInsetText(new InsetTextViewModel
+        {
+            Text = "If you do not receive a response within 10 working days, please contact Oxfordshire County Council directly."
+        })
+    }
+</p>
+
+<p class="govuk-body">To enquire about your application visit <a class="govuk-link"
+                                                                 href="https://www.oxfordshire.gov.uk/residents/environment-and-planning/energy-and-climate-change/retrofitting-your-home/retrofit-help-you">Oxfordshire
+        County Council's website</a>.</p>


### PR DESCRIPTION
[DESNZ-2200](https://softwiretech.atlassian.net/browse/DESNZ-2200)

# Description

- Added tests to detect changes in the status of LAs with custom wordings
- Refactored and auto-formatted `LocalAuthorityData`
  - Question: this also changed the way the local authority data looks is formatted, changing many lines. Should this be undone?
- Checked which custom wordings are inconsistent

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have introduced custom wording for an LA, I have checked the GOVUK Notify template reflects this wording
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the WHLG Portal repository](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

 <!-- Add any screenshots of your changes, if applicable --> 
