### PR TITLE
DESNZ-2191: Cached emergency state

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/Services/EmergencyMaintenance/EmergencyMaintenanceService.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Services/EmergencyMaintenance/EmergencyMaintenanceService.cs
@@ -4,9 +4,19 @@ namespace WhlgPublicWebsite.BusinessLogic.Services.EmergencyMaintenance;
 
 public class EmergencyMaintenanceService(IDataAccessProvider dataAccessProvider)
 {
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(30);
+    private EmergencyMaintenanceState? cachedState;
+    private DateTime timeLastStateFetch = DateTime.MinValue;
+
     public async Task<bool> SiteIsInEmergencyMaintenance()
     {
-        return await GetEmergencyMaintenanceState() == EmergencyMaintenanceState.Enabled;
+        if (IsCacheStale())
+        {
+            cachedState = await GetEmergencyMaintenanceState();
+            timeLastStateFetch = DateTime.UtcNow;
+        }
+
+        return cachedState == EmergencyMaintenanceState.Enabled;
     }
 
     public async Task<EmergencyMaintenanceState> GetEmergencyMaintenanceState()
@@ -26,5 +36,12 @@ public class EmergencyMaintenanceService(IDataAccessProvider dataAccessProvider)
         };
 
         await dataAccessProvider.AddEmergencyMaintenanceHistory(history);
+        cachedState = state;
+        timeLastStateFetch = DateTime.UtcNow;
+    }
+
+    private bool IsCacheStale()
+    {
+        return DateTime.UtcNow - timeLastStateFetch > CacheDuration;
     }
 }


### PR DESCRIPTION
﻿<!--
Add the ticket number below and uncomment
[DESNZ-2191](https://softwiretech.atlassian.net/browse/DESNZ-2191)
-->
[DESNZ-2191](https://softwiretech.atlassian.net/browse/DESNZ-2191)

# Description

 <!-- Add a brief description of the change(s) you have made --> 
- added a field to store the cached state and the timestamp of its last fetch
- changed the `SiteIsInEmergencyMaintenance` function to update the state and the timestamp if the cache is stale, and then return the cached state

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have introduced custom wording for an LA, I have checked the GOVUK Notify template reflects this wording
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the WHLG Portal repository](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

 <!-- Add any screenshots of your changes, if applicable --> 
