### PR TITLE
DESNZ-2239: Bolden Greater London Authority (GLA)

### DIFF
--- a/WhlgPublicWebsite/Views/Partials/LocalAuthorityMessages/Eligible/GreaterLondonAuthority.cshtml
+++ b/WhlgPublicWebsite/Views/Partials/LocalAuthorityMessages/Eligible/GreaterLondonAuthority.cshtml
@@ -1,7 +1,7 @@
 @model WhlgPublicWebsite.Models.Questionnaire.EligibleViewModel
 
 <p class="govuk-body">
-    Your application details will be shared with the Greater London Authority (GLA), which is managing Warm Homes: Local Grant applications on behalf of your borough using an online platform called Shared Works.
+    Your application details will be shared with the <b>Greater London Authority (GLA)</b>, which is managing Warm Homes: Local Grant applications on behalf of your borough using an online platform called Shared Works.
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
[Link to Jira ticket](https://softwiretech.atlassian.net/browse/DESNZ-2239)

# Description

Bolden the correct text in GLA wording

<img width="2560" height="1363" alt="image" src="https://github.com/user-attachments/assets/bbf47fdb-bac9-44bc-a0b9-c62408595ce7" />

