### PR TITLE
DESNZ-2169: Failure in OSPlaces now redirects to manual address entry

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/ExternalServices/Common/HttpRequestHelper.cs
+++ b/WhlgPublicWebsite.BusinessLogic/ExternalServices/Common/HttpRequestHelper.cs
@@ -40,6 +40,10 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.Common
             httpClient.BaseAddress = new Uri(parameters.BaseAddress);
             httpClient.DefaultRequestHeaders.Authorization = parameters.Auth;
             httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            if (parameters.Timeout is not null)
+            {
+                httpClient.Timeout = parameters.Timeout.Value;
+            }
             foreach (var headerDetails in parameters.Headers)
             {
                 httpClient.DefaultRequestHeaders.Add(headerDetails.Key, headerDetails.Value);
@@ -68,6 +72,7 @@ namespace WhlgPublicWebsite.BusinessLogic.ExternalServices.Common
         public AuthenticationHeaderValue Auth { get; set; }
         public HttpContent Body { get; set; }
         public Dictionary<string, string> Headers { get; set; } = new();
+        public TimeSpan? Timeout { get; set; }
     }
 
     internal enum RequestType

--- a/WhlgPublicWebsite.BusinessLogic/ExternalServices/OsPlaces/OsPlacesApi.cs
+++ b/WhlgPublicWebsite.BusinessLogic/ExternalServices/OsPlaces/OsPlacesApi.cs
@@ -12,6 +12,8 @@ public class OsPlacesApi(IOptions<OsPlacesConfiguration> options, ILogger<OsPlac
 {
     private readonly OsPlacesConfiguration config = options.Value;
     private const int MaxResults = 100;
+    // Shorter than typical ALB/app timeouts so failures are caught and users can continue via manual entry
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(15);
     private readonly Regex nonAlphanumericCharacters = new(@"[^a-zA-Z0-9]", RegexOptions.Compiled);
 
     public async Task<List<Address>> GetAddressesAsync(string postcode, string buildingNameOrNumber)
@@ -38,7 +40,7 @@ public class OsPlacesApi(IOptions<OsPlacesConfiguration> options, ILogger<OsPlac
                 {
                     parameters = GetRequestParameters(postcode, resultsRequested);
                     response = await HttpRequestHelper.SendGetRequestAsync<OsPlacesPostcodeResponseDto>(parameters);
-                    results = results.Concat(response.Results).ToList();
+                    results = results.Concat(response.Results ?? []).ToList();
                     resultsRequested += MaxResults;
                 }
             }
@@ -81,8 +83,8 @@ public class OsPlacesApi(IOptions<OsPlacesConfiguration> options, ILogger<OsPlac
         }
         catch (Exception e)
         {
-            logger.LogError("OS Places postcode request failed: {}", e.Message);
-            return [];
+            logger.LogError(e, "OS Places postcode request failed");
+            throw;
         }
     }
 
@@ -98,7 +100,8 @@ public class OsPlacesApi(IOptions<OsPlacesConfiguration> options, ILogger<OsPlac
         {
             BaseAddress = config.BaseUrl,
             Path = path,
-            Headers = new Dictionary<string, string> { { "Key", config.Key } }
+            Headers = new Dictionary<string, string> { { "Key", config.Key } },
+            Timeout = RequestTimeout
         };
     }
 }

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesApiTests.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/ExternalServices/OsPlaces/OsPlacesApiTests.cs
@@ -226,6 +226,21 @@ public class OsPlacesApiTests
         // Assert
         result.Count.Should().Be(0);
     }
+
+    [Test]
+    public async Task GetAddressesAsync_WhenOsPlacesRequestFails_Throws()
+    {
+        // Arrange
+        mockHttpHandler.Expect("http://test.com/search/places/v1/postcode?postcode=AB1%202CD")
+            .WithHeaders("Key", "testKey")
+            .Respond(System.Net.HttpStatusCode.ServiceUnavailable);
+
+        // Act
+        var act = async () => await underTest.GetAddressesAsync("AB1 2CD", "1");
+
+        // Assert — caller (SelectAddress) catches this and redirects to manual address entry
+        await act.Should().ThrowAsync<ApiException>();
+    }
     
     [Test]
     public async Task GetAddressesAsync_WhenThereAreMoreMatchesThanCanBeReturned_CallsOsPlacesAgain()

--- a/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
+++ b/WhlgPublicWebsite/Controllers/QuestionnaireController.cs
@@ -216,10 +216,21 @@ public class QuestionnaireController : Controller
     public async Task<IActionResult> SelectAddress_Get(string postcode, string buildingNameOrNumber,
         QuestionFlowStep? entryPoint)
     {
-        var addresses = await osPlaces.GetAddressesAsync(postcode, buildingNameOrNumber);
-
-        // autofill the postcode if the users presses manual entry, or if the below redirect happens
+        // autofill the postcode if the user presses manual entry, or if we redirect there on OS Places failure
         var questionnaire = await questionnaireService.UpdatePostcodeSearched(postcode, entryPoint);
+
+        List<Address> addresses;
+        try
+        {
+            addresses = await osPlaces.GetAddressesAsync(postcode, buildingNameOrNumber);
+        }
+        catch (Exception e)
+        {
+            // Unexpected OS Places failures (timeouts, 5xx, etc.) — let the user continue via manual entry.
+            // Failures are already logged in OsPlacesApi; healthchecks cover ongoing outages.
+            logger.LogWarning(e, "OS Places lookup failed; redirecting to manual address entry");
+            return RedirectToNextStep(QuestionFlowStep.ManualAddress, entryPoint);
+        }
 
         // 100 addresses is too many to show to user, ask for manual entry instead
         if (addresses.Count > 100)


### PR DESCRIPTION
﻿<!--
Add the ticket number below and uncomment
[Link to Jira ticket](https://softwiretech.atlassian.net/browse/DESNZ-####)
-->

# Description

 <!-- Add a brief description of the change(s) you have made --> 

- Added redirect to manual address entry in case of OS Places API failure
- Added timeout of 15 seconds for the requests (otherwise, if it is too long we risk the load balancer throwing an error first, which we wouldn't catch)
- Added test
- Added the error information when logging

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have introduced custom wording for an LA, I have checked the GOVUK Notify template reflects this wording
- [ ] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the WHLG Portal repository](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

