### PR TITLE
DESNZ-2261: Paused Sunderland City Council

### DIFF
--- a/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
+++ b/WhlgPublicWebsite.BusinessLogic/Models/LocalAuthorityData.cs
@@ -353,7 +353,7 @@ public class LocalAuthorityData
         { "3720", new LocalAuthorityDetails("Stratford-on-Avon District Council", LocalAuthorityStatus.ReferralsPaused, "https://www.stratford.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Nottingham City Council") },
         { "1625", new LocalAuthorityDetails("Stroud District Council", LocalAuthorityStatus.Live, "https://www.stroud.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Stroud District Council") },
         { "3500", new LocalAuthorityDetails("Suffolk County Council", LocalAuthorityStatus.ReferralsPaused, "https://www.suffolk.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Suffolk County Council") },
-        { "4525", new LocalAuthorityDetails("Sunderland City Council", LocalAuthorityStatus.Live, "https://www.sunderland.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
+        { "4525", new LocalAuthorityDetails("Sunderland City Council", LocalAuthorityStatus.ReferralsPaused, "https://www.sunderland.gov.uk", IncomeBandOptions[IncomeThreshold._36000], null) },
         { "3600", new LocalAuthorityDetails("Surrey County Council", LocalAuthorityStatus.Live, "https://www.surreycc.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
         { "3640", new LocalAuthorityDetails("Surrey Heath Borough Council", LocalAuthorityStatus.Live, "https://www.surreyheath.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], "Surrey County Council") },
         { "2255", new LocalAuthorityDetails("Swale Borough Council", LocalAuthorityStatus.NoFunding, "https://swale.gov.uk/", IncomeBandOptions[IncomeThreshold._36000], null) },

--- a/WhlgPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
+++ b/WhlgPublicWebsite.UnitTests/BusinessLogic/Models/ExpectedLocalAuthorityData/LocalAuthorityStatuses.cs
@@ -308,7 +308,7 @@ internal static class LocalAuthorityStatuses
             { "3720", ReferralsPaused },
             { "1625", Live },
             { "3500", ReferralsPaused },
-            { "4525", Live },
+            { "4525", ReferralsPaused },
             { "3600", Live },
             { "3640", Live },
             { "2255", NoFunding },


### PR DESCRIPTION
﻿<!--
Add the ticket number below and uncomment
-->

[Link to Jira ticket](https://softwiretech.atlassian.net/browse/DESNZ-2261)

# Description

 <!-- Add a brief description of the change(s) you have made --> 

- Updated local authority data and local authority statuses to match new SST and pause Sunderland City Council

# Checklist

- [x] I have made any necessary updates to the documentation
- [x] If necessary, I've added QA guidance notes to the original ticket
- [x] I have checked there are no unnecessary IDE warnings in this PR
- [x] I have checked there are no unintentional line ending changes
- [x] I have added tests where applicable
- [x] If I have made any changes to the code, I have used the IDE auto-formatter on it
- [x] If I have introduced custom wording for an LA, I have checked the GOVUK Notify template reflects this wording
- [x] If I have made any changes to website flow, I have updated the [Flow Miro Board](https://miro.com/app/board/uXjVL4Sjlmk=/)
- [x] If I have made any changes to website flow, I have checked forward and back behaviour is still consistent
- [x] If I have made any changes to the Local Authority or Consortium data, I have made sure these changes have been reflected in [the WHLG Portal repository](https://github.com/UKGovernmentBEIS/desnz-warm-homes-local-grant-portal)
- [x] If I have made any changes to the ReferralRequest model, I have made sure the data in FakeReferralGenerator.cs is still accurate

# Screenshots

 <!-- Add any screenshots of your changes, if applicable --> 

<img width="1907" height="1031" alt="image" src="https://github.com/user-attachments/assets/555245a3-74b1-4572-9ab5-773d45a139a4" />
